### PR TITLE
Reimplement storage deposits. Separate lockup deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ To test all the contracts locally, run the following command (note, it will buil
   - [ ] Add integration tests
   - [ ] Add documentation
 - veNEAR contract
-  - [ ] Ability to register account without deploying lockups.
-    - [ ] Reimplement as `storage_deposit` style integration.
-    - [ ] Lockup deployment should be optional.
+  - [X] Ability to register account without deploying lockups.
+    - [X] Reimplement as `storage_deposit` style integration.
+    - [X] Lockup deployment should be optional.
   - [X] Lockup contract integration
     - [X] Add ability to deploy lockup contract for the user
     - [X] Add methods that receive locked near balance from the lockup contract.
@@ -56,7 +56,7 @@ To test all the contracts locally, run the following command (note, it will buil
   - [X] Delegation
     - [X] Add ability to delegate veNEAR
     - [X] Add ability to undelegate veNEAR
-    - [X] When delegated veNEAR balance changes, it should be reflected in 2 places. The balance can't be redelgated.
+    - [X] When delegated veNEAR balance changes, it should be reflected in 2 places. The balance can't be redelegated.
   - [ ] Configuration changes
   - [ ] View methods for current lockup code
   - [ ] Owner's method to update config

--- a/common/src/lockup_update.rs
+++ b/common/src/lockup_update.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use near_sdk::json_types::U64;
 
 /// The lockup update is the information passed from the lockup contract to update veNEAR balances.
 /// It includes the total amount of NEAR that is locked in the lockup contract and the list of
@@ -14,7 +15,7 @@ pub struct LockupUpdateV1 {
 
     /// The nonce of the lockup update. It should be incremented for every new update by the lockup
     /// contract.
-    pub lockup_update_nonce: u64,
+    pub lockup_update_nonce: U64,
 }
 
 #[near(serializers=[borsh, json])]

--- a/venear-contract/src/lib.rs
+++ b/venear-contract/src/lib.rs
@@ -4,6 +4,7 @@ mod delegation;
 mod global_state;
 mod lockup;
 mod snapshot;
+mod storage;
 mod token;
 mod upgrade;
 

--- a/venear-contract/src/lockup.rs
+++ b/venear-contract/src/lockup.rs
@@ -2,9 +2,9 @@ use crate::account::AccountInternal;
 use crate::config::LockupContractConfig;
 use crate::*;
 use common::lockup_update::{LockupUpdateV1, VLockupUpdate};
-use common::{near_add, near_sub, VenearBalance};
+use common::near_add;
 use near_sdk::json_types::U64;
-use near_sdk::{env, is_promise_success, Gas, IntoStorageKey};
+use near_sdk::{env, is_promise_success, Gas, IntoStorageKey, Promise};
 
 const CONTRACT_CODE_EXTRA_STORAGE_BYTES: u64 = 100;
 
@@ -19,6 +19,9 @@ pub struct LockupInitArgs {
     // TODO
     lockup_duration: U64,
     staking_pool_whitelist_account_id: AccountId,
+
+    /// Starting nonce for lockup updates. It should be unique for every lockup contract.
+    lockup_update_nonce: U64,
 }
 
 #[near(serializers=[json])]
@@ -26,14 +29,23 @@ pub struct OnLockupDeployedArgs {
     version: Version,
 
     account_id: AccountId,
-    lockup_deposit: NearToken,
-    deposit: NearToken,
+
+    lockup_update_nonce: U64,
 }
 
 #[near]
 impl Contract {
-    /// Called by one of the lockup contracts to update the amount of
-    /// NEAR and fungible tokens locked in the lockup contract .
+    /// Deploys the lockup contract.
+    /// If the lockup contract is already deployed, the method will fail after the attempt.
+    /// Requires the caller to attach the deposit for the lockup contract of at least
+    /// `get_lockup_deployment_cost()`.
+    #[payable]
+    pub fn deploy_lockup(&mut self) {
+        self.internal_deploy_lockup(env::predecessor_account_id());
+    }
+
+    /// Called by one of the lockup contracts to update the amount of NEAR locked in the lockup
+    /// contract.
     pub fn on_lockup_update(
         &mut self,
         version: Version,
@@ -49,7 +61,7 @@ impl Contract {
             .internal_get_account_internal(&owner_account_id)
             .expect("Account not found");
         require!(
-            account_internal.version == version,
+            account_internal.version == Some(version),
             "Invalid lockup version"
         );
         match update {
@@ -64,30 +76,23 @@ impl Contract {
         &mut self,
         version: Version,
         account_id: AccountId,
+        lockup_update_nonce: U64,
         lockup_deposit: NearToken,
-        deposit: NearToken,
     ) {
         if is_promise_success() {
-            // Successfully deployed lockup. Creating internal account.
-            self.internal_set_account_internal(
-                account_id.clone(),
-                AccountInternal {
-                    version,
-                    deposit,
-                    lockup_update_nonce: 0,
-                },
+            let mut account_internal = self
+                .internal_get_account_internal(&account_id)
+                .expect("Account not found");
+            account_internal.version = Some(version);
+            require!(
+                account_internal.lockup_update_nonce <= lockup_update_nonce,
+                "Invalid nonce"
             );
-            let mut global_state: GlobalState = self.internal_global_state_updated();
-            let account = Account {
-                account_id: account_id.clone(),
-                update_timestamp: env::block_timestamp().into(),
-                balance: VenearBalance::from_near(near_add(lockup_deposit, deposit)),
-                delegated_balance: Default::default(),
-                delegation: None,
-            };
-            global_state.total_venear_balance += account.balance;
-            self.internal_set_account(account_id, account);
-            self.internal_set_global_state(global_state);
+            account_internal.lockup_update_nonce = lockup_update_nonce;
+            self.internal_set_account_internal(account_id, account_internal);
+        } else {
+            // Refunding the deposit if the lockup contract deployment failed.
+            Promise::new(account_id).transfer(lockup_deposit);
         }
     }
 }
@@ -156,7 +161,20 @@ impl Contract {
         });
     }
 
-    pub fn internal_deploy_lockup(&mut self, owner_account_id: AccountId, deposit: NearToken) {
+    pub fn internal_deploy_lockup(&mut self, owner_account_id: AccountId) {
+        let lockup_deposit = env::attached_deposit();
+        assert!(
+            self.internal_get_account_internal(&owner_account_id)
+                .is_some(),
+            "Account {} is not registered",
+            owner_account_id
+        );
+        let required_deposit = self.get_lockup_deployment_cost();
+        assert!(
+            lockup_deposit >= required_deposit,
+            "Not enough deposit. Required: {}",
+            required_deposit
+        );
         let lockup_contract_config = self
             .config
             .lockup_contract_config
@@ -184,6 +202,7 @@ impl Contract {
             )
         };
         let method_name = b"new";
+        let lockup_update_nonce = env::block_height() * 1_000_000;
         let arguments = LockupInitArgs {
             version: lockup_contract_config.contract_version,
             owner_account_id: owner_account_id.clone(),
@@ -192,11 +211,10 @@ impl Contract {
                 .config
                 .staking_pool_whitelist_account_id
                 .clone(),
+            lockup_update_nonce: lockup_update_nonce.into(),
         };
         let arguments =
             serde_json::to_vec(&arguments).expect("Failed to serialize lockup init args");
-        let local_deposit = self.config.local_deposit;
-        let lockup_deposit = near_sub(deposit, local_deposit);
         unsafe {
             sys::promise_batch_action_create_account(promise_id);
             sys::promise_batch_action_deploy_contract(promise_id, u64::MAX, CONTRACT_REGISTER);
@@ -217,8 +235,7 @@ impl Contract {
         let arguments = OnLockupDeployedArgs {
             version: lockup_contract_config.contract_version,
             account_id: owner_account_id.clone(),
-            lockup_deposit,
-            deposit: local_deposit,
+            lockup_update_nonce: lockup_update_nonce.into(),
         };
         let arguments =
             serde_json::to_vec(&arguments).expect("Failed to serialize lockup init args");

--- a/venear-contract/src/snapshot.rs
+++ b/venear-contract/src/snapshot.rs
@@ -2,10 +2,12 @@ use crate::*;
 
 #[near]
 impl Contract {
+    /// View method. Returns the current snapshot of the Merkle tree and the global state.
     pub fn get_snapshot(&self) -> (MerkleTreeSnapshot, VGlobalState) {
         self.tree.get_snapshot().expect("Snapshot is not available")
     }
 
+    /// View method. Returns the proof for the given account and the account value.
     pub fn get_proof(&self, account_id: AccountId) -> (MerkleProof, VAccount) {
         self.tree
             .get_proof(&account_id)

--- a/venear-contract/src/storage.rs
+++ b/venear-contract/src/storage.rs
@@ -1,0 +1,88 @@
+use crate::*;
+use common::near_add;
+use near_sdk::Promise;
+
+#[near(serializers=[json])]
+pub struct StorageBalance {
+    pub total: NearToken,
+    pub available: NearToken,
+}
+
+#[near(serializers=[json])]
+pub struct StorageBalanceBounds {
+    pub min: NearToken,
+    pub max: Option<NearToken>,
+}
+
+impl Contract {
+    fn internal_storage_balance_of(&self, account_id: &AccountId) -> Option<StorageBalance> {
+        if self.accounts.contains_key(account_id) {
+            Some(StorageBalance {
+                total: self.storage_balance_bounds().min,
+                available: NearToken::from_near(0),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[near]
+impl Contract {
+    /// Registers a new account. If the account is already registered, it refunds the attached
+    /// deposit.
+    #[payable]
+    pub fn storage_deposit(&mut self, account_id: Option<AccountId>) -> StorageBalance {
+        let amount = env::attached_deposit();
+        let account_id = account_id.unwrap_or_else(env::predecessor_account_id);
+        if self.internal_get_account_internal(&account_id).is_some() {
+            env::log_str("The account is already registered, refunding the deposit");
+            if amount > NearToken::from_near(0) {
+                Promise::new(env::predecessor_account_id()).transfer(amount);
+            }
+        } else {
+            let min_balance = self.storage_balance_bounds().min;
+            if amount < min_balance {
+                env::panic_str("The attached deposit is less than the minimum storage balance");
+            }
+
+            self.internal_register_account(&account_id, min_balance);
+            let refund = amount.saturating_sub(min_balance);
+            if refund > NearToken::from_near(0) {
+                Promise::new(env::predecessor_account_id()).transfer(refund);
+            }
+        }
+        self.internal_storage_balance_of(&account_id).unwrap()
+    }
+
+    /// Method to match the interface of the storage deposit. Fails with a panic.
+    #[payable]
+    pub fn storage_withdraw(&mut self) {
+        env::panic_str("Storage withdrawal is not supported");
+    }
+
+    /// Returns the minimum required balance to register an account.
+    pub fn storage_balance_bounds(&self) -> StorageBalanceBounds {
+        StorageBalanceBounds {
+            min: self.config.local_deposit,
+            max: Some(self.config.local_deposit),
+        }
+    }
+
+    /// Returns the minimum required balance to deploy a lockup.
+    pub fn get_lockup_deployment_cost(&self) -> NearToken {
+        let contract_deployment_cost = NearToken::from_yoctonear(
+            env::storage_byte_cost().as_yoctonear()
+                * self
+                    .config
+                    .lockup_contract_config
+                    .as_ref()
+                    .expect("Lockup contract is not set")
+                    .contract_size as u128,
+        );
+        near_add(
+            contract_deployment_cost,
+            self.config.min_extra_lockup_deposit,
+        )
+    }
+}


### PR DESCRIPTION
- Reimplement storage_deposit using standard interface
- Pass initial `lockup_update_nonce` to the lockup contract initialization.
- Update interface to use `U64` for `lockup_update_nonce`.
- Ability to deploy lockup multiple times. E.g. when lockup contract is deleted by the lockup for upgradability.