### PR TITLE
Voting contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ resolver = "2"
 members = [
     "lockup-contract",
     "venear-contract",
+    "voting-contract",
     "merkle-tree",
     "common",
     "integration-tests"

--- a/build_all.sh
+++ b/build_all.sh
@@ -13,3 +13,8 @@ pushd lockup-contract
 cargo near build non-reproducible-wasm --no-abi
 popd
 cp target/near/lockup_contract/lockup_contract.wasm res/local/
+
+pushd voting-contract
+cargo near build non-reproducible-wasm --no-abi
+popd
+cp target/near/voting_contract/voting_contract.wasm res/local/

--- a/common/src/account.rs
+++ b/common/src/account.rs
@@ -54,7 +54,7 @@ impl Account {
         &self,
         current_timestamp: TimestampNs,
         venear_growth_config: &VenearGrowthConfig,
-    ) -> NearToken {
+    ) -> VenearBalance {
         require!(
             current_timestamp >= self.update_timestamp,
             "Timestamp must be increasing"
@@ -68,7 +68,7 @@ impl Account {
             current_timestamp,
             venear_growth_config,
         );
-        total.total()
+        total
     }
 
     pub fn update(

--- a/common/src/global_state.rs
+++ b/common/src/global_state.rs
@@ -56,10 +56,4 @@ impl VGlobalState {
             VGlobalState::Current(global_state) => &global_state.venear_growth_config,
         }
     }
-
-    pub fn update(&mut self, current_timestamp: TimestampNs) {
-        match self {
-            VGlobalState::Current(global_state) => global_state.update(current_timestamp),
-        }
-    }
 }

--- a/common/src/global_state.rs
+++ b/common/src/global_state.rs
@@ -19,6 +19,15 @@ impl GlobalState {
             venear_growth_config,
         }
     }
+
+    pub fn update(&mut self, current_timestamp: TimestampNs) {
+        self.total_venear_balance.update(
+            self.update_timestamp,
+            current_timestamp,
+            &self.venear_growth_config,
+        );
+        self.update_timestamp = current_timestamp;
+    }
 }
 
 #[derive(Clone)]
@@ -45,6 +54,12 @@ impl VGlobalState {
     pub fn get_venear_growth_config(&self) -> &VenearGrowthConfig {
         match self {
             VGlobalState::Current(global_state) => &global_state.venear_growth_config,
+        }
+    }
+
+    pub fn update(&mut self, current_timestamp: TimestampNs) {
+        match self {
+            VGlobalState::Current(global_state) => global_state.update(current_timestamp),
         }
     }
 }

--- a/lockup-contract/src/venear_ext.rs
+++ b/lockup-contract/src/venear_ext.rs
@@ -4,6 +4,7 @@ use near_sdk::{ext_contract, AccountId};
 
 pub const GAS_FOR_VENEAR_LOCKUP_UPDATE: Gas = Gas::from_tgas(20);
 
+#[allow(dead_code)]
 #[ext_contract(ext_venear)]
 trait ExtVenear {
     fn on_lockup_update(

--- a/venear-contract/src/config.rs
+++ b/venear-contract/src/config.rs
@@ -30,7 +30,7 @@ pub struct Config {
     /// The minimum additional amount in NEAR required for lockup deployment.
     pub min_extra_lockup_deposit: NearToken,
 
-    /// The account ID that can upgrade the current contract.
+    /// The account ID that can upgrade the current contract and modify the config.
     pub owner_account_id: AccountId,
 }
 

--- a/venear-contract/src/global_state.rs
+++ b/venear-contract/src/global_state.rs
@@ -1,16 +1,9 @@
 use crate::*;
-use common::TimestampNs;
 
 impl Contract {
     pub fn internal_global_state_updated(&self) -> GlobalState {
         let mut global_state: GlobalState = self.tree.get_global_state().clone().into();
-        let current_timestamp: TimestampNs = env::block_timestamp().into();
-        global_state.total_venear_balance.update(
-            global_state.update_timestamp,
-            current_timestamp,
-            &global_state.venear_growth_config,
-        );
-        global_state.update_timestamp = current_timestamp;
+        global_state.update(env::block_timestamp().into());
         global_state
     }
 

--- a/venear-contract/src/lib.rs
+++ b/venear-contract/src/lib.rs
@@ -28,7 +28,6 @@ enum StorageKeys {
     Tree,
     LockupCode(CryptoHash),
     Accounts,
-    Lsts,
 }
 
 #[derive(PanicOnDefault)]

--- a/venear-contract/src/token.rs
+++ b/venear-contract/src/token.rs
@@ -8,10 +8,12 @@ impl Contract {
     pub fn ft_balance_of(&self, account_id: AccountId) -> NearToken {
         self.internal_get_account(&account_id)
             .map(|account| {
-                account.venear_balance(
-                    env::block_timestamp().into(),
-                    self.internal_get_venear_growth_config(),
-                )
+                account
+                    .venear_balance(
+                        env::block_timestamp().into(),
+                        self.internal_get_venear_growth_config(),
+                    )
+                    .total()
             })
             .unwrap_or_default()
     }

--- a/voting-contract/Cargo.toml
+++ b/voting-contract/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "voting-contract"
+description = "This crate provides the voting contract for the House of Stake"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+merkle-tree = { path = "../merkle-tree" }
+common = { path = "../common" }
+near-sdk.workspace = true
+serde_json.workspace = true

--- a/voting-contract/src/approver.rs
+++ b/voting-contract/src/approver.rs
@@ -1,0 +1,110 @@
+use crate::proposal::{Proposal, ProposalStatus, SnapshotAndState};
+use crate::*;
+use common::global_state::{GlobalState, VGlobalState};
+use common::TimestampNs;
+use near_sdk::{assert_one_yocto, ext_contract, Gas, Promise};
+use std::ops::Mul;
+
+pub const GAS_FOR_ON_GET_SNAPSHOT: Gas = Gas::from_tgas(30);
+
+#[near]
+impl Contract {
+    #[payable]
+    pub fn approve_proposal(
+        &mut self,
+        proposal_id: ProposalId,
+        voting_start_time_sec: Option<u32>,
+    ) -> Promise {
+        assert_one_yocto();
+        self.assert_called_by_approver();
+        let proposal = self.internal_expect_proposal_updated(proposal_id);
+
+        if proposal.status != ProposalStatus::Created {
+            env::panic_str("Proposal is not in the Created status");
+        }
+
+        ext_venear::ext(self.config.venear_account_id.clone())
+            .with_unused_gas_weight(1)
+            .get_snapshot()
+            .then(
+                ext_self::ext(env::current_account_id())
+                    .with_static_gas(GAS_FOR_ON_GET_SNAPSHOT)
+                    .on_get_snapshot(proposal_id, voting_start_time_sec),
+            )
+    }
+
+    #[payable]
+    pub fn reject_proposal(&mut self, proposal_id: ProposalId) {
+        assert_one_yocto();
+        self.assert_called_by_approver();
+        let mut proposal = self.internal_expect_proposal_updated(proposal_id);
+
+        if proposal.status != ProposalStatus::Created {
+            env::panic_str("Proposal is not in the Created status");
+        }
+
+        proposal.rejected = true;
+        proposal.status = ProposalStatus::Rejected;
+
+        self.internal_set_proposal(proposal);
+    }
+
+    #[private]
+    pub fn on_get_snapshot(
+        &mut self,
+        #[callback] snapshot_and_state: (MerkleTreeSnapshot, VGlobalState),
+        proposal_id: ProposalId,
+        voting_start_time_sec: Option<u32>,
+    ) -> Proposal {
+        let mut proposal = self.internal_expect_proposal_updated(proposal_id);
+
+        if proposal.status != ProposalStatus::Created {
+            env::panic_str("Proposal is not in the Created status");
+        }
+
+        let timestamp: TimestampNs = env::block_timestamp().into();
+
+        proposal.voting_start_time_ns = Some(
+            voting_start_time_sec
+                .map(|v| u64::from(v).mul(10u64.pow(9)).into())
+                .unwrap_or(timestamp),
+        );
+        require!(
+            proposal.voting_start_time_ns.unwrap() >= timestamp,
+            "Voting start time is in the past."
+        );
+
+        let mut global_state: GlobalState = snapshot_and_state.1.into();
+        global_state.update(timestamp.into());
+        proposal.snapshot_and_state = Some(SnapshotAndState {
+            snapshot: snapshot_and_state.0,
+            timestamp_ns: timestamp.into(),
+            total_venear: global_state.total_venear_balance.total(),
+            venear_growth_config: global_state.venear_growth_config,
+        });
+        proposal.status = ProposalStatus::Approved;
+
+        self.internal_set_proposal(proposal.clone());
+
+        proposal
+    }
+}
+
+impl Contract {
+    pub fn assert_called_by_approver(&self) {
+        require!(
+            env::predecessor_account_id() == self.config.approver_id,
+            "Only the approver can call this method"
+        );
+    }
+}
+
+#[ext_contract(ext_venear)]
+trait ExtVenear {
+    fn get_snapshot(&self);
+}
+
+#[ext_contract(ext_self)]
+trait ExtSelf {
+    fn on_get_snapshot(&mut self, proposal_id: ProposalId, voting_start_time_sec: Option<u32>);
+}

--- a/voting-contract/src/approver.rs
+++ b/voting-contract/src/approver.rs
@@ -99,11 +99,13 @@ impl Contract {
     }
 }
 
+#[allow(dead_code)]
 #[ext_contract(ext_venear)]
 trait ExtVenear {
     fn get_snapshot(&self);
 }
 
+#[allow(dead_code)]
 #[ext_contract(ext_self)]
 trait ExtSelf {
     fn on_get_snapshot(&mut self, proposal_id: ProposalId, voting_start_time_sec: Option<u32>);

--- a/voting-contract/src/config.rs
+++ b/voting-contract/src/config.rs
@@ -1,0 +1,28 @@
+use near_sdk::json_types::U64;
+use near_sdk::{near, AccountId, NearToken};
+
+#[derive(Debug, Clone)]
+#[near(serializers=[borsh, json])]
+pub struct Config {
+    /// The account ID of the veNEAR contract.
+    pub venear_account_id: AccountId,
+
+    /// The account ID that can approve proposals.
+    pub approver_id: AccountId,
+
+    /// The account ID that can upgrade the current contract and modify the config.
+    pub owner_account_id: AccountId,
+
+    /// The maximum duration of the voting period in nanoseconds.
+    pub voting_duration_ns: U64,
+
+    /// The maximum number of voting options per proposal.
+    pub max_number_of_voting_options: u16,
+
+    /// The fee that is paid to the contract for creating a proposal.
+    pub proposal_fee: NearToken,
+
+    /// Storage fee required to store a vote for an active proposal. It can be refunded once the
+    /// proposal is finalized.
+    pub vote_storage_fee: NearToken,
+}

--- a/voting-contract/src/governance.rs
+++ b/voting-contract/src/governance.rs
@@ -1,0 +1,12 @@
+use crate::*;
+use near_sdk::assert_one_yocto;
+use near_sdk::json_types::Base58CryptoHash;
+
+impl Contract {
+    pub fn assert_owner(&self) {
+        require!(
+            env::predecessor_account_id() == self.config.owner_account_id,
+            "Only the owner can call this method"
+        );
+    }
+}

--- a/voting-contract/src/governance.rs
+++ b/voting-contract/src/governance.rs
@@ -1,6 +1,4 @@
 use crate::*;
-use near_sdk::assert_one_yocto;
-use near_sdk::json_types::Base58CryptoHash;
 
 impl Contract {
     pub fn assert_owner(&self) {

--- a/voting-contract/src/lib.rs
+++ b/voting-contract/src/lib.rs
@@ -6,7 +6,6 @@ use merkle_tree::{MerkleProof, MerkleTreeSnapshot};
 use crate::config::Config;
 use crate::proposal::{ProposalId, VProposal};
 use common::account::*;
-use common::global_state::*;
 use common::venear::VenearGrowthConfig;
 use near_sdk::store::{LookupMap, Vector};
 use near_sdk::{env, near, require, AccountId, BorshStorageKey, NearToken, PanicOnDefault};

--- a/voting-contract/src/lib.rs
+++ b/voting-contract/src/lib.rs
@@ -1,5 +1,8 @@
+mod approver;
 mod config;
+mod governance;
 mod proposal;
+mod upgrade;
 
 use merkle_tree::{MerkleProof, MerkleTreeSnapshot};
 
@@ -14,7 +17,6 @@ use near_sdk::{env, near, require, AccountId, BorshStorageKey, NearToken, PanicO
 #[near]
 enum StorageKeys {
     Proposals,
-    StorageBalances,
     Votes,
     ApprovedProposals,
 }
@@ -24,7 +26,6 @@ enum StorageKeys {
 pub struct Contract {
     config: Config,
     proposals: Vector<VProposal>,
-    storage_balances: LookupMap<AccountId, NearToken>,
     /// A map from the account ID and the proposal ID to the vote option index.
     votes: LookupMap<(AccountId, ProposalId), u32>,
     approved_proposals: Vector<ProposalId>,
@@ -37,7 +38,6 @@ impl Contract {
         Self {
             config,
             proposals: Vector::new(StorageKeys::Proposals),
-            storage_balances: LookupMap::new(StorageKeys::StorageBalances),
             votes: LookupMap::new(StorageKeys::Votes),
             approved_proposals: Vector::new(StorageKeys::ApprovedProposals),
         }

--- a/voting-contract/src/lib.rs
+++ b/voting-contract/src/lib.rs
@@ -1,0 +1,46 @@
+mod config;
+mod proposal;
+
+use merkle_tree::{MerkleProof, MerkleTreeSnapshot};
+
+use crate::config::Config;
+use crate::proposal::{ProposalId, VProposal};
+use common::account::*;
+use common::global_state::*;
+use common::venear::VenearGrowthConfig;
+use near_sdk::store::{LookupMap, Vector};
+use near_sdk::{env, near, require, AccountId, BorshStorageKey, NearToken, PanicOnDefault};
+
+#[derive(BorshStorageKey)]
+#[near]
+enum StorageKeys {
+    Proposals,
+    StorageBalances,
+    Votes,
+    ApprovedProposals,
+}
+
+#[derive(PanicOnDefault)]
+#[near(contract_state)]
+pub struct Contract {
+    config: Config,
+    proposals: Vector<VProposal>,
+    storage_balances: LookupMap<AccountId, NearToken>,
+    /// A map from the account ID and the proposal ID to the vote option index.
+    votes: LookupMap<(AccountId, ProposalId), u32>,
+    approved_proposals: Vector<ProposalId>,
+}
+
+#[near]
+impl Contract {
+    #[init]
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            proposals: Vector::new(StorageKeys::Proposals),
+            storage_balances: LookupMap::new(StorageKeys::StorageBalances),
+            votes: LookupMap::new(StorageKeys::Votes),
+            approved_proposals: Vector::new(StorageKeys::ApprovedProposals),
+        }
+    }
+}

--- a/voting-contract/src/proposal.rs
+++ b/voting-contract/src/proposal.rs
@@ -1,0 +1,299 @@
+use crate::*;
+use common::{TimestampNs, VenearBalance};
+use near_sdk::json_types::U64;
+
+pub type ProposalId = u32;
+
+#[derive(Clone)]
+#[near(serializers=[borsh])]
+pub enum VProposal {
+    Current(Proposal),
+}
+
+impl From<Proposal> for VProposal {
+    fn from(current: Proposal) -> Self {
+        Self::Current(current)
+    }
+}
+
+impl From<VProposal> for Proposal {
+    fn from(value: VProposal) -> Self {
+        match value {
+            VProposal::Current(current) => current,
+        }
+    }
+}
+
+#[derive(Clone)]
+#[near(serializers=[borsh, json])]
+pub struct Proposal {
+    /// The unique identifier of the proposal, generated automatically.
+    pub id: ProposalId,
+    /// The timestamp in nanoseconds when the proposal was created, generated automatically.
+    pub creation_time_ns: U64,
+    /// The account ID of the proposer.
+    pub proposer_id: AccountId,
+    /// The metadata of the proposal, provided by the proposer.
+    pub metadata: ProposalMetadata,
+    /// The timestamp when the voting starts, provided by the approver.
+    pub voting_start_time_ns: Option<U64>,
+    /// The voting duration in nanoseconds, generated from the config.
+    pub voting_duration_ns: U64,
+    /// The flag indicating if the proposal was rejected by the approver.
+    pub rejected: bool,
+    /// The snapshot of the contract state and global state. Fetched when the proposal is approved.
+    pub snapshot_and_state: Option<SnapshotAndState>,
+    /// Aggregated votes per voting option.
+    pub votes: Vec<VoteStats>,
+    /// The total aggregated voting information across all voting options.
+    pub total_votes: VoteStats,
+    /// The status of the proposal. It's optional and can be computed from the proposal itself.
+    pub status: ProposalStatus,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+#[near(serializers=[borsh, json])]
+pub enum ProposalStatus {
+    /// The proposal was created and is waiting for the approver to approve or reject it.
+    Created,
+    /// The proposal was rejected by the approver.
+    Rejected,
+    /// The proposal was approved by the approver and is waiting for the voting to start.
+    Approved,
+    /// The proposal is in the voting phase.
+    Voting,
+    /// The proposal voting is finished and the results are available.
+    Finished,
+}
+
+#[derive(Clone)]
+#[near(serializers=[borsh, json])]
+pub struct SnapshotAndState {
+    /// The snapshot of the Merkle tree at the moment when the proposal was approved.
+    pub snapshot: MerkleTreeSnapshot,
+    /// The global state at the moment when the proposal was approved.
+    pub global_state: VGlobalState,
+}
+
+#[derive(Clone)]
+#[near(serializers=[borsh, json])]
+pub struct ProposalMetadata {
+    /// The title of the proposal.
+    pub title: Option<String>,
+
+    /// The description of the proposal.
+    pub description: Option<String>,
+
+    /// The link to the proposal.
+    pub link: Option<String>,
+
+    /// The voting options for the proposal.
+    pub voting_options: Vec<String>,
+}
+
+#[derive(Clone)]
+#[near(serializers=[borsh, json])]
+pub struct VoteStats {
+    /// The timestamp in nanoseconds when the stats were updated.
+    pub update_timestamp: TimestampNs,
+
+    /// The total venear balance at the updated timestamp.
+    pub total_venear: VenearBalance,
+
+    /// The total number of votes.
+    pub total_votes: u32,
+}
+
+impl Default for VoteStats {
+    fn default() -> Self {
+        Self {
+            update_timestamp: env::block_timestamp().into(),
+            total_venear: VenearBalance::default(),
+            total_votes: 0,
+        }
+    }
+}
+
+impl VoteStats {
+    pub fn update(
+        &mut self,
+        current_timestamp: TimestampNs,
+        venear_growth_config: &VenearGrowthConfig,
+    ) {
+        self.total_venear.update(
+            self.update_timestamp,
+            current_timestamp,
+            venear_growth_config,
+        );
+        self.update_timestamp = current_timestamp;
+    }
+}
+
+impl Proposal {
+    pub fn internal_get_venear_growth_config(&self) -> Option<&VenearGrowthConfig> {
+        Some(
+            self.snapshot_and_state
+                .as_ref()?
+                .global_state
+                .get_venear_growth_config(),
+        )
+    }
+
+    pub fn update(&mut self, mut timestamp: TimestampNs) {
+        match self.status {
+            ProposalStatus::Created | ProposalStatus::Rejected | ProposalStatus::Finished => {
+                return;
+            }
+            ProposalStatus::Approved => {
+                if timestamp >= self.voting_start_time_ns.unwrap() {
+                    self.status = ProposalStatus::Voting;
+                }
+            }
+            _ => {}
+        }
+        // Note, handling it outside the match in case it was approved before.
+        if self.status == ProposalStatus::Voting {
+            if timestamp.0 >= self.voting_start_time_ns.unwrap().0 + self.voting_duration_ns.0 {
+                self.status = ProposalStatus::Finished;
+                // We don't want to update the proposal after the voting is finished.
+                timestamp =
+                    (self.voting_start_time_ns.unwrap().0 + self.voting_duration_ns.0).into();
+            }
+        }
+
+        self.snapshot_and_state
+            .as_mut()
+            .unwrap()
+            .global_state
+            .update(timestamp);
+
+        let venear_growth_config = self.internal_get_venear_growth_config().unwrap().clone();
+
+        self.total_votes.update(timestamp, &venear_growth_config);
+        for vote in self.votes.iter_mut() {
+            vote.update(timestamp, &venear_growth_config);
+        }
+    }
+}
+
+#[near]
+impl Contract {
+    #[payable]
+    pub fn create_proposal(&mut self, metadata: ProposalMetadata) -> ProposalId {
+        let attached_deposit = env::attached_deposit();
+        require!(
+            attached_deposit == self.config.proposal_fee,
+            format!(
+                "Requires deposit of {}",
+                self.config.proposal_fee.exact_amount_display()
+            )
+        );
+
+        let num_voting_options = metadata.voting_options.len();
+
+        require!(
+            num_voting_options >= 2,
+            "Requires at least 2 voting options"
+        );
+
+        require!(
+            num_voting_options <= self.config.max_number_of_voting_options as usize,
+            format!(
+                "Too many voting options, max is {}",
+                self.config.max_number_of_voting_options
+            )
+        );
+
+        let proposer_id = env::predecessor_account_id();
+        let proposal_id = self.proposals.len();
+        let proposal = Proposal {
+            id: proposal_id,
+            creation_time_ns: env::block_timestamp().into(),
+            proposer_id,
+            metadata,
+            voting_start_time_ns: None,
+            voting_duration_ns: self.config.voting_duration_ns,
+            rejected: false,
+            snapshot_and_state: None,
+            votes: vec![VoteStats::default(); num_voting_options],
+            total_votes: VoteStats::default(),
+            status: ProposalStatus::Created,
+        };
+        self.proposals.push(proposal.into());
+        proposal_id
+    }
+
+    pub fn vote(
+        &mut self,
+        proposal_id: ProposalId,
+        vote: u32,
+        merkle_proof: MerkleProof,
+        v_account: VAccount,
+    ) {
+        let mut proposal: Proposal = self.internal_expect_proposal_update(proposal_id);
+
+        match proposal.status {
+            ProposalStatus::Voting => {}
+            ProposalStatus::Created | ProposalStatus::Approved => {
+                env::panic_str("Voting is not started yet");
+            }
+            ProposalStatus::Rejected => {
+                env::panic_str("Proposal is rejected");
+            }
+            ProposalStatus::Finished => {
+                env::panic_str("Voting is finished");
+            }
+        }
+
+        let account: Account = v_account.clone().into();
+        let account_id = &account.account_id;
+        // Validate proof
+        {
+            let SnapshotAndState { snapshot, .. } = proposal.snapshot_and_state.as_ref().unwrap();
+            merkle_proof.verify(snapshot.root.into(), snapshot.length, &v_account);
+        }
+
+        let timestamp_ns: TimestampNs = env::block_timestamp().into();
+        let account_balance = account.venear_balance(
+            timestamp_ns,
+            proposal.internal_get_venear_growth_config().unwrap(),
+        );
+
+        let previous_vote = self.votes.get(&(account_id.clone(), proposal_id)).cloned();
+        require!(
+            previous_vote != Some(vote),
+            "Already voted for the same option"
+        );
+        if let Some(previous_vote) = previous_vote {
+            proposal.votes[previous_vote as usize].total_votes -= 1;
+            proposal.votes[previous_vote as usize].total_venear -= account_balance;
+            proposal.total_votes.total_votes -= 1;
+            proposal.total_votes.total_venear -= account_balance;
+        }
+        proposal.votes[vote as usize].total_votes += 1;
+        proposal.votes[vote as usize].total_venear += account_balance;
+        proposal.total_votes.total_votes += 1;
+        proposal.total_votes.total_venear += account_balance;
+    }
+
+    pub fn get_proposal(&self, proposal_id: ProposalId) -> Option<Proposal> {
+        self.internal_get_proposal(proposal_id)
+    }
+}
+
+impl Contract {
+    pub fn internal_get_proposal(&self, proposal_id: ProposalId) -> Option<Proposal> {
+        self.proposals
+            .get(proposal_id)
+            .cloned()
+            .map(|proposal| proposal.into())
+    }
+
+    pub fn internal_expect_proposal_update(&self, proposal_id: ProposalId) -> Proposal {
+        let mut proposal = self
+            .internal_get_proposal(proposal_id)
+            .expect(format!("Proposal {} is not found", proposal_id).as_str());
+        proposal.update(env::block_timestamp().into());
+        proposal
+    }
+}

--- a/voting-contract/src/upgrade.rs
+++ b/voting-contract/src/upgrade.rs
@@ -1,0 +1,22 @@
+use crate::*;
+
+#[near]
+impl Contract {
+    #[private]
+    #[init(ignore_state)]
+    pub fn upgrade_state() -> Self {
+        todo!();
+    }
+
+    pub fn get_version(&self) -> String {
+        env!("CARGO_PKG_VERSION").to_string()
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn upgrade() {
+    env::setup_panic_hook();
+    let contract: Contract = env::state_read().unwrap();
+    contract.assert_owner();
+    todo!();
+}


### PR DESCRIPTION
- Initial implementation of the voting contract
  - Ability to create a proposal, approve a proposal, reject a proposal and vote on a proposals.
  - Basic configuration: one approver account.
  - Require storage payment for every vote (should be able to recover it once the voting is done).