### PR TITLE
Rename versioning from Current to V0

### DIFF
--- a/common/src/account.rs
+++ b/common/src/account.rs
@@ -31,19 +31,19 @@ pub struct AccountDelegation {
 #[derive(Clone)]
 #[near(serializers=[borsh, json])]
 pub enum VAccount {
-    Current(Account),
+    V0(Account),
 }
 
 impl From<Account> for VAccount {
     fn from(account: Account) -> Self {
-        Self::Current(account)
+        Self::V0(account)
     }
 }
 
 impl From<VAccount> for Account {
     fn from(value: VAccount) -> Self {
         match value {
-            VAccount::Current(account) => account,
+            VAccount::V0(account) => account,
         }
     }
 }

--- a/common/src/global_state.rs
+++ b/common/src/global_state.rs
@@ -33,19 +33,19 @@ impl GlobalState {
 #[derive(Clone)]
 #[near(serializers=[borsh, json])]
 pub enum VGlobalState {
-    Current(GlobalState),
+    V0(GlobalState),
 }
 
 impl From<GlobalState> for VGlobalState {
     fn from(global_state: GlobalState) -> Self {
-        Self::Current(global_state)
+        Self::V0(global_state)
     }
 }
 
 impl From<VGlobalState> for GlobalState {
     fn from(value: VGlobalState) -> Self {
         match value {
-            VGlobalState::Current(global_state) => global_state,
+            VGlobalState::V0(global_state) => global_state,
         }
     }
 }
@@ -53,7 +53,7 @@ impl From<VGlobalState> for GlobalState {
 impl VGlobalState {
     pub fn get_venear_growth_config(&self) -> &VenearGrowthConfig {
         match self {
-            VGlobalState::Current(global_state) => &global_state.venear_growth_config,
+            VGlobalState::V0(global_state) => &global_state.venear_growth_config,
         }
     }
 }


### PR DESCRIPTION
- Rename versioning from `Current` to `V0`, so during the upgrades, the version doesn't need to be renamed and wouldn't affect JSON serialization.