### PR TITLE
Fix rounding issue

### DIFF
--- a/API.md
+++ b/API.md
@@ -9,8 +9,9 @@ The API documentation for the contracts.
 /// Note, the growth rate can be changed in the future through the upgrade mechanism, by introducing
 /// timepoints when the growth rate changes.
 pub struct VenearGrowthConfigFixedRate {
-    /// The growth rate of veNEAR tokens per nanosecond. E.g. 6 / (100 * NUM_SEC_IN_YEAR * 10**9)
+    /// The growth rate of veNEAR tokens per nanosecond. E.g. `6 / (100 * NUM_SEC_IN_YEAR * 10**9)`
     /// means 6% annual growth rate.
+    /// Note, the denominator has to be `10**30` to avoid precision issues.
     pub annual_growth_rate_ns: Fraction,
 }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "near-sdk",
  "serde",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "common",
  "near-sdk",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "lockup-contract"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "common",
  "near-sdk",
@@ -1450,7 +1450,7 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "merkle-tree"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "near-sdk",
  "serde_json",
@@ -2527,7 +2527,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sandbox-staking-whitelist-contract"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "near-sdk",
  "serde_json",
@@ -3354,7 +3354,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "venear-contract"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "common",
  "hex",
@@ -3371,7 +3371,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voting-contract"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "common",
  "merkle-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Fastnear Inc <hello@fastnear.com>"]
 edition = "2021"
 repository = "https://github.com/fastnear/house-of-stake-contracts"

--- a/common/src/global_state.rs
+++ b/common/src/global_state.rs
@@ -7,7 +7,7 @@ use crate::*;
 pub struct GlobalState {
     pub update_timestamp: TimestampNs,
 
-    pub total_venear_balance: VenearBalance,
+    pub total_venear_balance: PooledVenearBalance,
 
     pub venear_growth_config: VenearGrowthConfig,
 }
@@ -15,13 +15,14 @@ pub struct GlobalState {
 impl GlobalState {
     pub fn new(timestamp: TimestampNs, venear_growth_config: VenearGrowthConfig) -> Self {
         Self {
-            update_timestamp: timestamp,
-            total_venear_balance: VenearBalance::default(),
+            update_timestamp: truncate_to_seconds(timestamp),
+            total_venear_balance: PooledVenearBalance::default(),
             venear_growth_config,
         }
     }
 
     pub fn update(&mut self, current_timestamp: TimestampNs) {
+        let current_timestamp = truncate_to_seconds(current_timestamp);
         self.total_venear_balance.update(
             self.update_timestamp,
             current_timestamp,

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -116,9 +116,7 @@ impl PooledVenearBalance {
         self.0
             .update(previous_timestamp, current_timestamp, venear_growth_config);
     }
-}
 
-impl PooledVenearBalance {
     pub fn pooled_add(&self, other: &VenearBalance) -> Self {
         let truncated_near_balance = truncate_near_to_millis(other.near_balance);
         let difference = near_sub(other.near_balance, truncated_near_balance);

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -8,6 +8,14 @@ pub fn near_sub(a: NearToken, b: NearToken) -> NearToken {
     a.checked_sub(b).unwrap()
 }
 
+pub fn truncate_to_seconds(nanoseconds: TimestampNs) -> TimestampNs {
+    (nanoseconds.0 / 1_000_000_000 * 1_000_000_000).into()
+}
+
+pub fn truncate_near_to_millis(near: NearToken) -> NearToken {
+    NearToken::from_millinear(near.as_millinear())
+}
+
 // Tests for `near_add` and `near_sub`
 #[cfg(test)]
 mod tests {

--- a/common/src/venear.rs
+++ b/common/src/venear.rs
@@ -38,13 +38,14 @@ impl VenearGrowthConfig {
         if previous_timestamp == current_timestamp {
             return NearToken::from_yoctonear(0);
         }
+        let truncated_near_balance = truncate_near_to_millis(balance);
         match self {
             VenearGrowthConfig::FixedRate(config) => {
                 let growth_period_ns = current_timestamp.0 - previous_timestamp.0;
                 NearToken::from_yoctonear(
                     config
                         .annual_growth_rate_ns
-                        .u384_mul(growth_period_ns as _, balance.as_yoctonear()),
+                        .u384_mul(growth_period_ns as _, truncated_near_balance.as_yoctonear()),
                 )
             }
         }

--- a/common/src/venear.rs
+++ b/common/src/venear.rs
@@ -13,8 +13,9 @@ pub enum VenearGrowthConfig {
 #[derive(Clone)]
 #[near(serializers=[json, borsh])]
 pub struct VenearGrowthConfigFixedRate {
-    /// The growth rate of veNEAR tokens per nanosecond. E.g. 6 / (100 * NUM_SEC_IN_YEAR * 10**9)
+    /// The growth rate of veNEAR tokens per nanosecond. E.g. `6 / (100 * NUM_SEC_IN_YEAR * 10**9)`
     /// means 6% annual growth rate.
+    /// Note, the denominator has to be `10**30` to avoid precision issues.
     pub annual_growth_rate_ns: Fraction,
 }
 
@@ -34,6 +35,14 @@ impl VenearGrowthConfig {
         require!(
             current_timestamp >= previous_timestamp,
             "Timestamp must be increasing"
+        );
+        require!(
+            current_timestamp == truncate_to_seconds(current_timestamp),
+            "Current timestamp must be truncated to seconds"
+        );
+        require!(
+            previous_timestamp == truncate_to_seconds(previous_timestamp),
+            "Previous timestamp must be truncated to seconds"
         );
         if previous_timestamp == current_timestamp {
             return NearToken::from_yoctonear(0);

--- a/integration-tests/tests/setup/mod.rs
+++ b/integration-tests/tests/setup/mod.rs
@@ -60,9 +60,13 @@ impl Default for VenearTestWorkspaceBuilder {
             unlock_duration_ns: UNLOCK_DURATION_SECONDS * 1_000_000_000,
             local_deposit: NearToken::from_millinear(100),
             min_lockup_deposit: NearToken::from_millinear(2000),
+            // 6% annual growth rate, expressed as a fraction per nanosecond
+            // 6 / (100 * 365 * 24 * 60 * 60 * 10**9)
+            // The denominator is set to 10**30 to avoid precision issues with large numbers.
+            // So the numerator is rounded to the closest integer 1902587519025.8752
             annual_growth_rate_ns: Fraction {
-                numerator: 6.into(),
-                denominator: (100u128 * 365 * 24 * 60 * 60 * 10u128.pow(9)).into(),
+                numerator: 1902587519026.into(),
+                denominator: 10u128.pow(30).into(),
             },
             deploy_voting: false,
             voting_duration_ns: VOTING_DURATION_SECONDS * 1_000_000_000,

--- a/integration-tests/tests/test_venear.rs
+++ b/integration-tests/tests/test_venear.rs
@@ -239,8 +239,8 @@ async fn test_venear_growth() -> Result<(), Box<dyn std::error::Error>> {
     // Configure the annual growth rate to be 10% per selected period
     let v = VenearTestWorkspaceBuilder::default()
         .annual_growth_rate_ns(Fraction {
-            numerator: 10.into(),
-            denominator: (100 * period).into(),
+            numerator: (10 * 10u128.pow(30) / (100 * period)).into(),
+            denominator: 10u128.pow(30).into(),
         })
         .build()
         .await?;
@@ -287,7 +287,7 @@ async fn test_venear_growth() -> Result<(), Box<dyn std::error::Error>> {
     assert_almost_eq(
         balance,
         new_expected_balance,
-        NearToken::from_millinear(100),
+        NearToken::from_millinear(200),
     );
 
     Ok(())
@@ -298,7 +298,7 @@ async fn test_ft_events() -> Result<(), Box<dyn std::error::Error>> {
     let v = VenearTestWorkspaceBuilder::default()
         .annual_growth_rate_ns(Fraction {
             numerator: 0.into(),
-            denominator: 1.into(),
+            denominator: 10u128.pow(30).into(),
         })
         .build()
         .await?;

--- a/scripts/deploy_all.sh
+++ b/scripts/deploy_all.sh
@@ -84,8 +84,8 @@ near --quiet contract deploy $VENEAR_ACCOUNT_ID use-file res/$CONTRACTS_SOURCE/v
   },
   "venear_growth_config": {
     "annual_growth_rate_ns": {
-      "numerator": "6",
-      "denominator": "3153600000000000000"
+      "numerator": "1902587519026",
+      "denominator": "1000000000000000000000000000000"
     }
   }
 }' prepaid-gas '10.0 Tgas' attached-deposit '0 NEAR' network-config $CHAIN_ID sign-with-keychain send

--- a/scripts/deploy_all.sh
+++ b/scripts/deploy_all.sh
@@ -57,10 +57,10 @@ export VOTING_GUARDIAN_ACCOUNT_ID="voting-guardian.$ROOT_ACCOUNT_ID"
 export LOCKUP_DEPLOYER_ACCOUNT_ID="lockup-deployer.$ROOT_ACCOUNT_ID"
 
 echo "Creating account $VENEAR_ACCOUNT_ID"
-near --quiet account create-account fund-myself $VENEAR_ACCOUNT_ID '2.3 NEAR' autogenerate-new-keypair save-to-keychain sign-as $ROOT_ACCOUNT_ID network-config $CHAIN_ID sign-with-keychain send
+near --quiet account create-account fund-myself $VENEAR_ACCOUNT_ID '2.4 NEAR' autogenerate-new-keypair save-to-keychain sign-as $ROOT_ACCOUNT_ID network-config $CHAIN_ID sign-with-keychain send
 
 echo "Creating account $VOTING_ACCOUNT_ID"
-near --quiet account create-account fund-myself $VOTING_ACCOUNT_ID '2.2 NEAR' autogenerate-new-keypair save-to-keychain sign-as $ROOT_ACCOUNT_ID network-config $CHAIN_ID sign-with-keychain send
+near --quiet account create-account fund-myself $VOTING_ACCOUNT_ID '2.3 NEAR' autogenerate-new-keypair save-to-keychain sign-as $ROOT_ACCOUNT_ID network-config $CHAIN_ID sign-with-keychain send
 
 echo "Creating account $OWNER_ACCOUNT_ID"
 near --quiet account create-account fund-myself $OWNER_ACCOUNT_ID '0.1 NEAR' autogenerate-new-keypair save-to-keychain sign-as $ROOT_ACCOUNT_ID network-config $CHAIN_ID sign-with-keychain send

--- a/venear-contract/src/delegation.rs
+++ b/venear-contract/src/delegation.rs
@@ -23,7 +23,9 @@ impl Contract {
         }
 
         let mut delegation_account = self.internal_expect_account_updated(&receiver_id);
-        delegation_account.delegated_balance += account.balance;
+        delegation_account.delegated_balance = delegation_account
+            .delegated_balance
+            .pooled_add(&account.balance);
         self.internal_set_account(receiver_id.clone(), delegation_account);
 
         account.delegation = Some(AccountDelegation {
@@ -49,7 +51,9 @@ impl Contract {
     pub fn internal_undelegate(&mut self, account: &mut Account) {
         let delegation_account_id = account.delegation.take().expect("Not delegated").account_id;
         let mut delegation_account = self.internal_expect_account_updated(&delegation_account_id);
-        delegation_account.delegated_balance -= account.balance;
+        delegation_account.delegated_balance = delegation_account
+            .delegated_balance
+            .pooled_sub(&account.balance);
         self.internal_set_account(delegation_account_id, delegation_account);
     }
 }

--- a/venear-contract/src/lib.rs
+++ b/venear-contract/src/lib.rs
@@ -48,6 +48,12 @@ impl Contract {
     /// Initializes the contract with the given configuration.
     #[init]
     pub fn new(config: Config, venear_growth_config: VenearGrowthConfigFixedRate) -> Self {
+        // The denominator must be 10^30 (10^9 for nanoseconds and 10^21 for milliNEAR) to ensure
+        // that the growth rate doesn't introduce rounding errors.
+        require!(
+            venear_growth_config.annual_growth_rate_ns.denominator.0 == 10u128.pow(30),
+            "Denominator must be 10^30"
+        );
         Self {
             tree: MerkleTree::new(
                 StorageKeys::Tree,

--- a/venear-contract/src/lockup.rs
+++ b/venear-contract/src/lockup.rs
@@ -162,14 +162,18 @@ impl Contract {
         // Updating balance and also adding internal balance deposit.
         account.balance.near_balance =
             near_add(lockup_update.locked_near_balance, account_internal.deposit);
-        global_state.total_venear_balance -= old_balance;
-        global_state.total_venear_balance += account.balance;
+        global_state.total_venear_balance = global_state
+            .total_venear_balance
+            .pooled_sub(&old_balance)
+            .pooled_add(&account.balance);
 
         if let Some(delegation) = &account.delegation {
             let mut delegation_account =
                 self.internal_expect_account_updated(&delegation.account_id);
-            delegation_account.delegated_balance -= old_balance;
-            delegation_account.delegated_balance += account.balance;
+            delegation_account.delegated_balance = delegation_account
+                .delegated_balance
+                .pooled_sub(&old_balance)
+                .pooled_add(&account.balance);
             self.internal_set_account(delegation.account_id.clone(), delegation_account);
         }
         self.internal_set_account_internal(account_id.clone(), account_internal);

--- a/venear-contract/src/token.rs
+++ b/venear-contract/src/token.rs
@@ -8,12 +8,10 @@ impl Contract {
     pub fn ft_balance_of(&self, account_id: AccountId) -> NearToken {
         self.internal_get_account(&account_id)
             .map(|account| {
-                account
-                    .venear_balance(
-                        env::block_timestamp().into(),
-                        self.internal_get_venear_growth_config(),
-                    )
-                    .total()
+                account.total_balance(
+                    env::block_timestamp().into(),
+                    self.internal_get_venear_growth_config(),
+                )
             })
             .unwrap_or_default()
     }

--- a/voting-contract/src/votes.rs
+++ b/voting-contract/src/votes.rs
@@ -52,16 +52,14 @@ impl Contract {
             account_id == &env::predecessor_account_id(),
             "Account ID doesn't match the predecessor account ID"
         );
-        let account_balance = account
-            .venear_balance(
-                timestamp_ns,
-                &proposal
-                    .snapshot_and_state
-                    .as_ref()
-                    .unwrap()
-                    .venear_growth_config,
-            )
-            .total();
+        let account_balance = account.total_balance(
+            timestamp_ns,
+            &proposal
+                .snapshot_and_state
+                .as_ref()
+                .unwrap()
+                .venear_growth_config,
+        );
         require!(!account_balance.is_zero(), "Account has no veNEAR balance");
 
         let previous_vote = self.votes.get(&(account_id.clone(), proposal_id)).cloned();


### PR DESCRIPTION
This PR fixes rounding inaccuracies in balance calculations by switching from raw arithmetic to pooled arithmetic operations, adding truncation logic to minimize rounding errors, and enforcing a strict denominator for growth calculations.

**The issue**
- Let's say account A delegated to B at T1.
- Then B was affected at T2 (so balances were recalculated including growth)
- Then at T3, A tries to undelegate from B, and balance growth at (T3-T1) is higher due to rounding down than twice (T2-T1) and (T3-T2). It causes a panic at checked subtraction operation which prevents A from undelegating.

Branch https://github.com/fastnear/house-of-stake-contracts/tree/delegation-test introduced a test to verify the issue in the previous contract version. This test was failing before and passes now.

**The fix**
To fix the issue we enforce the growth denominator to be `10**30`. When computing extra_venear growth, we truncate time to seconds (from nanoseconds `10**9`), and venear balance to milli-near (`10**21`). This way the multiplier in the numerator is guaranteed to be divisible by `10**30`.

When pooling venear like delegation or computing total, we have to add up truncated venear as well to avoid compounding growth from multiple accounts, so we introduce `PooledVenearBalance`.

**Changes:**
- Updated calls from venear_balance to total_balance to include updated arithmetic and truncation.
- Introduced pooled operations (pooled_add and pooled_sub) across contracts to better handle rounding precision.
- Added a denominator check and truncation utility functions to further reduce rounding discrepancies.
- Added test