### PR TITLE
Log extra_venear_balance at time of lockup update 

### DIFF
--- a/common/src/events.rs
+++ b/common/src/events.rs
@@ -14,6 +14,9 @@ pub mod emit {
         pub(crate) timestamp: &'a Option<TimestampNs>,
         pub(crate) lockup_update_nonce: &'a Option<U64>,
         pub(crate) locked_near_balance: &'a Option<NearToken>,
+        pub(crate) extra_venear_balance: &'a Option<NearToken>,
+        /// The timestamp used for calculating extra_venear_balance (rewards accrued up to this point)
+        pub(crate) rewards_calculated_at: &'a Option<TimestampNs>,
     }
 
     #[derive(Serialize)]
@@ -88,6 +91,8 @@ pub mod emit {
         lockup_update_nonce: &Option<U64>,
         timestamp: &Option<TimestampNs>,
         locked_near_balance: &Option<NearToken>,
+        extra_venear_balance: &Option<NearToken>,
+        rewards_calculated_at: &Option<TimestampNs>,
     ) {
         log_event(
             "venear",
@@ -98,6 +103,8 @@ pub mod emit {
                 lockup_update_nonce,
                 timestamp,
                 locked_near_balance,
+                extra_venear_balance,
+                rewards_calculated_at,
             },
         );
     }
@@ -230,18 +237,22 @@ mod tests {
         let balance = Some(NearToken::from_yoctonear(1000000000000000000000000));
         let version: u64 = 1;
 
+        let extra_venear = Some(NearToken::from_yoctonear(500000000000000000000000));
+        let rewards_calculated_at = Some(U64(123456790)); // Slightly after timestamp
         let test_data = emit::LockupUpdateData {
             account_id: &account_id,
             lockup_version: version,
             timestamp: &timestamp,
             lockup_update_nonce: &nonce,
             locked_near_balance: &balance,
+            extra_venear_balance: &extra_venear,
+            rewards_calculated_at: &rewards_calculated_at,
         };
 
         let json = serde_json::to_string(&test_data).unwrap();
         assert_eq!(
             json,
-            r#"{"account_id":"test.near","lockup_version":1,"timestamp":"123456789","lockup_update_nonce":"42","locked_near_balance":"1000000000000000000000000"}"#
+            r#"{"account_id":"test.near","lockup_version":1,"timestamp":"123456789","lockup_update_nonce":"42","locked_near_balance":"1000000000000000000000000","extra_venear_balance":"500000000000000000000000","rewards_calculated_at":"123456790"}"#
         );
 
         // Test with None values
@@ -251,12 +262,14 @@ mod tests {
             timestamp: &None,
             lockup_update_nonce: &None,
             locked_near_balance: &None,
+            extra_venear_balance: &None,
+            rewards_calculated_at: &None,
         };
 
         let json = serde_json::to_string(&test_data).unwrap();
         assert_eq!(
             json,
-            r#"{"account_id":"test.near","lockup_version":1,"timestamp":null,"lockup_update_nonce":null,"locked_near_balance":null}"#
+            r#"{"account_id":"test.near","lockup_version":1,"timestamp":null,"lockup_update_nonce":null,"locked_near_balance":null,"extra_venear_balance":null,"rewards_calculated_at":null}"#
         );
     }
 
@@ -268,6 +281,8 @@ mod tests {
         let balance = Some(NearToken::from_yoctonear(5555555555555555555));
         let version: u64 = 1;
 
+        let extra_venear = Some(NearToken::from_yoctonear(1111111111111111111));
+        let rewards_calculated_at = Some(U64(987654321987654322));
         emit::lockup_action(
             "test_event",
             &account_id,
@@ -275,12 +290,14 @@ mod tests {
             &nonce,
             &timestamp,
             &balance,
+            &extra_venear,
+            &rewards_calculated_at,
         );
 
         // The actual log would need to be captured and verified
         // This is just a format check example
         let _expected_log = format!(
-            r#"EVENT_JSON:{{"standard":"venear","version":"1.0.0","event":"test_event","data":[{{"account_id":"event_test.near","lockup_version":1,"timestamp":"987654321","lockup_update_nonce":"777","locked_near_balance":"5555555555555555555"}}]}}"#
+            r#"EVENT_JSON:{{"standard":"venear","version":"1.0.0","event":"test_event","data":[{{"account_id":"event_test.near","lockup_version":1,"timestamp":"987654321","lockup_update_nonce":"777","locked_near_balance":"5555555555555555555","extra_venear_balance":"1111111111111111111","rewards_calculated_at":"987654321987654322"}}]}}"#
         );
         // Normally you would check the actual logs here
     }

--- a/lockup-contract/src/owner.rs
+++ b/lockup-contract/src/owner.rs
@@ -473,6 +473,8 @@ impl LockupContract {
             &Some(U64::from(self.lockup_update_nonce)),
             &None,
             &None,
+            &None,
+            &None,
         );
 
         Promise::new(env::current_account_id()).delete_account(self.owner_account_id.clone())

--- a/lockup-contract/src/venear.rs
+++ b/lockup-contract/src/venear.rs
@@ -96,6 +96,8 @@ impl LockupContract {
             &Some(U64::from(self.lockup_update_nonce)),
             &Some(U64::from(env::block_timestamp())),
             &Some(NearToken::from_yoctonear(amount)),
+            &None,
+            &None,
         );
 
         self.venear_lockup_update();

--- a/venear-contract/src/lockup.rs
+++ b/venear-contract/src/lockup.rs
@@ -75,15 +75,7 @@ impl Contract {
 
         match update {
             VLockupUpdate::V1(lockup_update) => {
-                events::emit::lockup_action(
-                    "lockup_update",
-                    &owner_account_id,
-                    version,
-                    &Some(lockup_update.lockup_update_nonce),
-                    &Some(lockup_update.timestamp),
-                    &Some(lockup_update.locked_near_balance),
-                );
-                self.internal_lockup_update(owner_account_id, account_internal, lockup_update);
+                self.internal_lockup_update(owner_account_id, account_internal, lockup_update, version);
             }
         }
     }
@@ -116,6 +108,8 @@ impl Contract {
                 &None,
                 &None,
                 &None,
+                &None,
+                &None,
             );
 
             self.internal_set_account_internal(account_id.clone(), account_internal);
@@ -145,12 +139,16 @@ impl Contract {
         account_id: AccountId,
         mut account_internal: AccountInternal,
         lockup_update: LockupUpdateV1,
+        version: Version,
     ) {
         require!(
             lockup_update.lockup_update_nonce > account_internal.lockup_update_nonce,
             "Invalid nonce"
         );
         account_internal.lockup_update_nonce = lockup_update.lockup_update_nonce;
+
+        // Capture the timestamp used for reward calculation (this is what internal_expect_account_updated uses)
+        let rewards_calculated_at = env::block_timestamp();
 
         let mut account: Account = self.internal_expect_account_updated(&account_id);
         let old_balance = account.balance;
@@ -162,6 +160,19 @@ impl Contract {
         // Updating balance and also adding internal balance deposit.
         account.balance.near_balance =
             near_add(lockup_update.locked_near_balance, account_internal.deposit);
+
+        // Emit event after balance is computed so extra_venear_balance is available
+        events::emit::lockup_action(
+            "lockup_update",
+            &account_id,
+            version,
+            &Some(lockup_update.lockup_update_nonce),
+            &Some(lockup_update.timestamp),
+            &Some(lockup_update.locked_near_balance),
+            &Some(account.balance.extra_venear_balance),
+            &Some(rewards_calculated_at.into()),
+        );
+
         global_state.total_venear_balance = global_state
             .total_venear_balance
             .pooled_sub(&old_balance)


### PR DESCRIPTION
## PR Description

### Add `extra_venear_balance` and `rewards_calculated_at` to lockup_update events

This change exposes the computed veNEAR rewards in the `lockup_update` event logs, enabling off-chain indexers to track account balances (principal + rewards) without needing to call the contract directly.

**Changes:**
- Added `extra_venear_balance` field to capture accrued rewards at the time of update
- Added `rewards_calculated_at` timestamp to indicate exactly when rewards were calculated (may differ from `timestamp` due to cross-contract call timing)
- Moved event emission inside `internal_lockup_update` where the computed balance is available

**New event fields:**
```json
{
  "extra_venear_balance": "20560490690631170000000000000",
  "rewards_calculated_at": "1767630818900000000"
}
```

**Files changed:**
- `common/src/events.rs` - Added new fields to `LockupUpdateData` struct and `lockup_action` function
- `venear-contract/src/lockup.rs` - Emit event after balance computation with actual timestamp
- `lockup-contract/src/venear.rs` - Updated call site
- `lockup-contract/src/owner.rs` - Updated call site