### PR TITLE
Fix partial-delegation rounding + veNEAR forfeit on small lockup increases

### DIFF
--- a/common/src/account.rs
+++ b/common/src/account.rs
@@ -89,17 +89,6 @@ impl From<VAccount> for Account {
 }
 
 impl Account {
-    /// Sum of `bps` across all delegation entries. Always `<= 10_000` for well-formed accounts
-    /// (enforced by `validate_delegations` at write time).
-    pub fn delegated_bps(&self) -> u16 {
-        self.delegations
-            .iter()
-            .map(|delegation| u32::from(delegation.bps))
-            .sum::<u32>()
-            .try_into()
-            .expect("delegation bps sum must fit into u16")
-    }
-
     /// Returns veNEAR balance of the account at the given timestamp without modifications.
     pub fn total_balance(
         &self,
@@ -224,44 +213,5 @@ mod tests {
         assert_eq!(account.delegations.len(), 2);
         assert_eq!(account.delegations[0].bps, Bps::new(2_500));
         assert_eq!(account.delegations[1].bps, Bps::new(7_500));
-    }
-
-    #[test]
-    fn delegated_bps_empty_is_zero() {
-        assert_eq!(sample_account(vec![]).delegated_bps(), 0);
-    }
-
-    #[test]
-    fn delegated_bps_sums_partial_entries() {
-        let account = sample_account(vec![
-            DelegationEntry {
-                account_id: account_id("a.near"),
-                bps: Bps::new(1_234),
-            },
-            DelegationEntry {
-                account_id: account_id("b.near"),
-                bps: Bps::new(2_000),
-            },
-            DelegationEntry {
-                account_id: account_id("c.near"),
-                bps: Bps::new(766),
-            },
-        ]);
-        assert_eq!(account.delegated_bps(), 4_000);
-    }
-
-    #[test]
-    fn delegated_bps_full_allocation() {
-        let account = sample_account(vec![
-            DelegationEntry {
-                account_id: account_id("a.near"),
-                bps: Bps::new(6_000),
-            },
-            DelegationEntry {
-                account_id: account_id("b.near"),
-                bps: Bps::new(4_000),
-            },
-        ]);
-        assert_eq!(account.delegated_bps(), 10_000);
     }
 }

--- a/common/src/account.rs
+++ b/common/src/account.rs
@@ -100,36 +100,26 @@ impl Account {
             .expect("delegation bps sum must fit into u16")
     }
 
-    /// Returns veNEAR balance of the account without modifications.
+    /// Returns veNEAR balance of the account at the given timestamp without modifications.
     pub fn total_balance(
         &self,
         current_timestamp: TimestampNs,
         venear_growth_config: &VenearGrowthConfig,
     ) -> NearToken {
-        let current_timestamp = truncate_to_seconds(current_timestamp);
-        require!(
-            current_timestamp >= self.update_timestamp,
-            "Timestamp must be increasing"
-        );
-        let mut delegated_balance = self.delegated_balance;
-        delegated_balance.update(
-            self.update_timestamp,
-            current_timestamp,
-            venear_growth_config,
-        );
-        let total = delegated_balance.total();
-        let self_bps = Bps::new(10_000_u16.saturating_sub(self.delegated_bps()));
-        if !self_bps.is_zero() {
-            let mut balance = self.balance;
-            balance.update(
-                self.update_timestamp,
-                current_timestamp,
-                venear_growth_config,
-            );
-            near_add(total, balance.scale_by_bps(self_bps).total())
-        } else {
-            total
+        let mut account = self.clone();
+        account.update(current_timestamp, venear_growth_config);
+        account.owned_total()
+    }
+
+    /// The voting power owned by this account: incoming delegated balance plus own balance minus
+    /// the exact `delegation_contribution` of each outgoing delegation, so the sub-milliNEAR
+    /// remainders stay with the owner. Assumes the balances are already updated.
+    pub fn owned_total(&self) -> NearToken {
+        let mut retained = self.balance;
+        for delegation in &self.delegations {
+            retained = retained - self.balance.delegation_contribution(delegation.bps);
         }
+        near_add(self.delegated_balance.total(), retained.total())
     }
 
     pub fn update(

--- a/common/src/bps.rs
+++ b/common/src/bps.rs
@@ -45,21 +45,12 @@ impl Bps {
         }
     }
 
-    pub const fn as_u16(self) -> u16 {
-        self.0
-    }
-
     pub const fn is_zero(self) -> bool {
         self.0 == 0
     }
 
     pub const fn is_full(self) -> bool {
         self.0 == Self::MAX_RAW
-    }
-
-    /// `Bps::FULL - self`. Always in range because `self.0 <= 10_000`.
-    pub const fn complement(self) -> Self {
-        Self(Self::MAX_RAW - self.0)
     }
 }
 
@@ -119,9 +110,9 @@ mod tests {
 
     #[test]
     fn try_new_accepts_in_range() {
-        assert_eq!(Bps::try_new(0).unwrap().as_u16(), 0);
-        assert_eq!(Bps::try_new(3_500).unwrap().as_u16(), 3_500);
-        assert_eq!(Bps::try_new(10_000).unwrap().as_u16(), 10_000);
+        assert_eq!(u16::from(Bps::try_new(0).unwrap()), 0);
+        assert_eq!(u16::from(Bps::try_new(3_500).unwrap()), 3_500);
+        assert_eq!(u16::from(Bps::try_new(10_000).unwrap()), 10_000);
     }
 
     #[test]
@@ -140,9 +131,8 @@ mod tests {
     fn const_constructors() {
         assert!(Bps::ZERO.is_zero());
         assert!(Bps::FULL.is_full());
-        assert_eq!(Bps::FULL.complement(), Bps::ZERO);
-        assert_eq!(Bps::ZERO.complement(), Bps::FULL);
-        assert_eq!(Bps::new(2_500).complement(), Bps::new(7_500));
+        assert_eq!(u16::from(Bps::ZERO), 0);
+        assert_eq!(u16::from(Bps::FULL), Bps::MAX_RAW);
     }
 
     #[test]

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -81,19 +81,6 @@ impl VenearBalance {
             extra_venear_balance: NearToken::from_yoctonear(extra.as_u128()),
         }
     }
-
-    pub fn scale_by_bps(&self, bps: Bps) -> Self {
-        if bps.is_zero() {
-            return Self::default();
-        }
-        if bps.is_full() {
-            return *self;
-        }
-        Self {
-            near_balance: bps * self.near_balance,
-            extra_venear_balance: bps * self.extra_venear_balance,
-        }
-    }
 }
 
 impl Add<Self> for VenearBalance {
@@ -130,10 +117,11 @@ impl SubAssign<Self> for VenearBalance {
     }
 }
 
-/// Represents balance of NEAR and veNEAR tokens that are pooled together. The `near_balance` is
-/// truncated to milliNEAR for every added `VenearBalance` to avoid rounding errors
-/// during `extra_venear_balance` growth calculations. The truncated `near_balance` is added to
-/// `extra_venear_balance` to ensure that the total balance remains consistent.
+/// Represents balance of NEAR and veNEAR tokens that are pooled together. The pool's
+/// `near_balance` holds only whole milliNEAR so extra veNEAR growth on it stays exact.
+/// `pooled_add`/`pooled_sub` (global totals) fold the sub-milliNEAR near remainder into
+/// `extra_venear_balance` to conserve the total; `pooled_add_delegation`/`pooled_sub_delegation`
+/// credit the exact `delegation_contribution` instead, leaving the remainder with the owner.
 #[derive(Copy, Clone, Default)]
 #[near(serializers=[borsh, json])]
 pub struct PooledVenearBalance(VenearBalance);
@@ -244,63 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn scale_by_bps_zero_returns_zero() {
-        let balance = VenearBalance {
-            near_balance: NearToken::from_near(100),
-            extra_venear_balance: NearToken::from_near(50),
-        };
-        let scaled = balance.scale_by_bps(Bps::ZERO);
-        assert_eq!(scaled.near_balance.as_yoctonear(), 0);
-        assert_eq!(scaled.extra_venear_balance.as_yoctonear(), 0);
-    }
-
-    #[test]
-    fn scale_by_bps_full_returns_full() {
-        let balance = VenearBalance {
-            near_balance: NearToken::from_near(100),
-            extra_venear_balance: NearToken::from_near(50),
-        };
-        let scaled = balance.scale_by_bps(Bps::FULL);
-        assert_eq!(
-            scaled.near_balance.as_yoctonear(),
-            balance.near_balance.as_yoctonear()
-        );
-        assert_eq!(
-            scaled.extra_venear_balance.as_yoctonear(),
-            balance.extra_venear_balance.as_yoctonear()
-        );
-    }
-
-    #[test]
-    fn scale_by_bps_half_returns_half() {
-        let balance = VenearBalance {
-            near_balance: NearToken::from_near(100),
-            extra_venear_balance: NearToken::from_near(50),
-        };
-        let scaled = balance.scale_by_bps(Bps::new(5_000));
-        assert_eq!(
-            scaled.near_balance.as_yoctonear(),
-            NearToken::from_near(50).as_yoctonear()
-        );
-        assert_eq!(
-            scaled.extra_venear_balance.as_yoctonear(),
-            NearToken::from_near(25).as_yoctonear()
-        );
-    }
-
-    #[test]
-    fn scale_by_bps_99_near_3333bps() {
-        let balance = VenearBalance {
-            near_balance: NearToken::from_near(99),
-            extra_venear_balance: NearToken::from_near(0),
-        };
-        let scaled = balance.scale_by_bps(Bps::new(3_333));
-        let expected_yocto = (99_000_000_000_000_000_000_000_000u128 * 3_333) / 10_000;
-        assert_eq!(scaled.near_balance.as_yoctonear(), expected_yocto);
-    }
-
-    #[test]
-    fn pooled_add_delegation_then_sub_scaled_is_identity() {
+    fn pooled_add_delegation_then_sub_delegation_is_identity() {
         let initial = PooledVenearBalance(VenearBalance {
             near_balance: NearToken::from_near(1000),
             extra_venear_balance: NearToken::from_near(500),
@@ -324,7 +256,7 @@ mod tests {
     /// Mirrors mainnet tx HDtSFscvJQ7G6rA6Xy9XWdEnyLhaKJVPJbTDyyycChHX: a 2512 bps share of
     /// 4.1 NEAR is not milliNEAR-aligned, and after growth the old formula under-charged the pool.
     #[test]
-    fn pooled_scaled_sub_after_growth_is_exact() {
+    fn delegation_contribution_sub_after_growth_is_exact() {
         let mut balance = VenearBalance {
             near_balance: NearToken::from_millinear(4_100),
             extra_venear_balance: NearToken::from_yoctonear(50_000_000_000_000_000_000_000),
@@ -351,17 +283,49 @@ mod tests {
         );
     }
 
+    /// Sweeps misaligned balances, extras, bps and growth windows: the delegation credit grown
+    /// over the window must equal the debit recomputed from the grown owner balance, exactly.
     #[test]
-    fn scale_by_bps_extra_venear_scaled() {
-        let balance = VenearBalance {
-            near_balance: NearToken::from_near(0),
-            extra_venear_balance: NearToken::from_near(100),
-        };
-        let scaled = balance.scale_by_bps(Bps::new(2_500));
-        assert_eq!(scaled.near_balance.as_yoctonear(), 0);
-        assert_eq!(
-            scaled.extra_venear_balance.as_yoctonear(),
-            NearToken::from_near(25).as_yoctonear()
-        );
+    fn delegation_contribution_growth_exactness_grid() {
+        let day_ns: u64 = 86_400_000_000_000;
+        let near_values: [u128; 5] = [
+            10u128.pow(24),
+            4_100 * 10u128.pow(21),
+            4_100 * 10u128.pow(21) + 999_999,
+            9 * 10u128.pow(20),
+            777 * 10u128.pow(24) + 777,
+        ];
+        let extra_values: [u128; 4] = [
+            0,
+            5 * 10u128.pow(22),
+            1_234_567_890_123_456_789,
+            12 * 10u128.pow(25),
+        ];
+        let bps_values: [u16; 5] = [1, 777, 2_512, 9_999, 10_000];
+        let day_values: [u64; 4] = [1, 27, 365, 3_650];
+        for &near in &near_values {
+            for &extra in &extra_values {
+                for &bps_raw in &bps_values {
+                    for &days in &day_values {
+                        let mut balance = VenearBalance {
+                            near_balance: NearToken::from_yoctonear(near),
+                            extra_venear_balance: NearToken::from_yoctonear(extra),
+                        };
+                        let bps = Bps::new(bps_raw);
+                        let mut pool =
+                            PooledVenearBalance::default().pooled_add_delegation(&balance, bps);
+                        let end: TimestampNs = (days * day_ns).into();
+                        pool.update(0.into(), end, &growth_config());
+                        balance.update(0.into(), end, &growth_config());
+                        let after_sub = pool.pooled_sub_delegation(&balance, bps);
+                        assert_eq!(after_sub.0.near_balance, NearToken::from_yoctonear(0));
+                        assert_eq!(
+                            after_sub.0.extra_venear_balance,
+                            NearToken::from_yoctonear(0)
+                        );
+                    }
+                }
+            }
+        }
     }
 }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -26,7 +26,7 @@ pub type Version = u64;
 
 /// Represents balance of NEAR and veNEAR tokens. NEAR tokens grow over time, while veNEAR tokens
 /// do not.
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[near(serializers=[borsh, json])]
 pub struct VenearBalance {
     /// The balance in NEAR tokens. This balance doesn't grow over time.
@@ -122,7 +122,7 @@ impl SubAssign<Self> for VenearBalance {
 /// `pooled_add`/`pooled_sub` (global totals) fold the sub-milliNEAR near remainder into
 /// `extra_venear_balance` to conserve the total; `pooled_add_delegation`/`pooled_sub_delegation`
 /// credit the exact `delegation_contribution` instead, leaving the remainder with the owner.
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[near(serializers=[borsh, json])]
 pub struct PooledVenearBalance(VenearBalance);
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -64,6 +64,24 @@ impl VenearBalance {
         }
     }
 
+    /// The exact share of this balance credited to a delegate's pool. Extra is split by the
+    /// realized ratio truncate_millis(bps × near ∕ MAX_BPS) ∕ truncate_millis(near) — not by bps —
+    /// so recomputing after any growth returns exactly the pool credit plus its growth.
+    pub fn delegation_contribution(&self, bps: Bps) -> Self {
+        let base = truncate_near_to_millis(self.near_balance);
+        if base.is_zero() {
+            return Self::default();
+        }
+        let near_balance = truncate_near_to_millis(bps * self.near_balance);
+        let extra = U256::from(self.extra_venear_balance.as_yoctonear())
+            * U256::from(near_balance.as_yoctonear())
+            / U256::from(base.as_yoctonear());
+        Self {
+            near_balance,
+            extra_venear_balance: NearToken::from_yoctonear(extra.as_u128()),
+        }
+    }
+
     pub fn scale_by_bps(&self, bps: Bps) -> Self {
         if bps.is_zero() {
             return Self::default();
@@ -159,14 +177,12 @@ impl PooledVenearBalance {
         })
     }
 
-    pub fn pooled_add_scaled(&self, other: &VenearBalance, bps: Bps) -> Self {
-        let scaled = other.scale_by_bps(bps);
-        self.pooled_add(&scaled)
+    pub fn pooled_add_delegation(&self, other: &VenearBalance, bps: Bps) -> Self {
+        Self(self.0 + other.delegation_contribution(bps))
     }
 
-    pub fn pooled_sub_scaled(&self, other: &VenearBalance, bps: Bps) -> Self {
-        let scaled = other.scale_by_bps(bps);
-        self.pooled_sub(&scaled)
+    pub fn pooled_sub_delegation(&self, other: &VenearBalance, bps: Bps) -> Self {
+        Self(self.0 - other.delegation_contribution(bps))
     }
 }
 
@@ -214,6 +230,18 @@ impl Fraction {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::venear::VenearGrowthConfigFixedRate;
+
+    /// Production growth rate: 6% annual, per nanosecond (same as `test_utils::growth_config`).
+    fn growth_config() -> VenearGrowthConfig {
+        VenearGrowthConfigFixedRate {
+            annual_growth_rate_ns: Fraction {
+                numerator: U128(1_902_587_519_026),
+                denominator: U128(10u128.pow(30)),
+            },
+        }
+        .into()
+    }
 
     #[test]
     fn scale_by_bps_zero_returns_zero() {
@@ -272,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn pooled_add_scaled_then_sub_scaled_is_identity() {
+    fn pooled_add_delegation_then_sub_scaled_is_identity() {
         let initial = PooledVenearBalance(VenearBalance {
             near_balance: NearToken::from_near(1000),
             extra_venear_balance: NearToken::from_near(500),
@@ -283,18 +311,43 @@ mod tests {
         };
         let bps = Bps::new(5_000);
 
-        let after_add = initial.pooled_add_scaled(&to_add, bps);
-        let after_sub = after_add.pooled_sub_scaled(&to_add, bps);
+        let after_add = initial.pooled_add_delegation(&to_add, bps);
+        let after_sub = after_add.pooled_sub_delegation(&to_add, bps);
 
-        // Pooled truncation allows up to 1 milliNEAR drift.
-        let tolerance: i128 = 1_000_000_000_000_000;
-        let got = i128::try_from(after_sub.0.near_balance.as_yoctonear()).unwrap();
-        let expected = i128::try_from(initial.0.near_balance.as_yoctonear()).unwrap();
-        assert!(
-            (got - expected).abs() <= tolerance,
-            "near_balance mismatch: expected ~{}, got {}",
-            expected,
-            got
+        assert_eq!(after_sub.0.near_balance, initial.0.near_balance);
+        assert_eq!(
+            after_sub.0.extra_venear_balance,
+            initial.0.extra_venear_balance
+        );
+    }
+
+    /// Mirrors mainnet tx HDtSFscvJQ7G6rA6Xy9XWdEnyLhaKJVPJbTDyyycChHX: a 2512 bps share of
+    /// 4.1 NEAR is not milliNEAR-aligned, and after growth the old formula under-charged the pool.
+    #[test]
+    fn pooled_scaled_sub_after_growth_is_exact() {
+        let mut balance = VenearBalance {
+            near_balance: NearToken::from_millinear(4_100),
+            extra_venear_balance: NearToken::from_yoctonear(50_000_000_000_000_000_000_000),
+        };
+        let bps = Bps::new(2_512);
+
+        let contribution = balance.delegation_contribution(bps);
+        assert_eq!(contribution.near_balance, NearToken::from_millinear(1_029));
+        assert_eq!(
+            contribution.extra_venear_balance,
+            NearToken::from_yoctonear(12_548_780_487_804_878_048_780)
+        );
+
+        let mut pool = PooledVenearBalance::default().pooled_add_delegation(&balance, bps);
+        let day_ns: u64 = 86_400_000_000_000;
+        pool.update(0.into(), (27 * day_ns).into(), &growth_config());
+        balance.update(0.into(), (27 * day_ns).into(), &growth_config());
+
+        let after_sub = pool.pooled_sub_delegation(&balance, bps);
+        assert_eq!(after_sub.0.near_balance, NearToken::from_yoctonear(0));
+        assert_eq!(
+            after_sub.0.extra_venear_balance,
+            NearToken::from_yoctonear(0)
         );
     }
 

--- a/integration-tests/tests/setup/mainnet.rs
+++ b/integration-tests/tests/setup/mainnet.rs
@@ -1,0 +1,175 @@
+//! Helpers for pulling live mainnet contracts (code + state) into a sandbox.
+#![allow(dead_code)]
+
+use base64::Engine;
+use near_sdk::NearToken;
+use near_workspaces::network::Sandbox;
+use near_workspaces::types::{KeyType, SecretKey};
+use near_workspaces::{AccessKey, Account, AccountDetailsPatch, AccountId, Contract, Worker};
+use serde_json::json;
+
+pub const MAINNET_RPC: &str = "https://rpc.intea.rs";
+
+/// Fetch the account's on-chain `storage_usage`. Patched accounts must carry the real value:
+/// the sandbox patch defaults it to 0, and the first state write that replaces an existing
+/// value then underflows the account's storage accounting and crashes the sandbox node.
+pub async fn fetch_mainnet_storage_usage(
+    client: &reqwest::Client,
+    account_id: &str,
+) -> Result<u64, Box<dyn std::error::Error>> {
+    let response: serde_json::Value = client
+        .post(MAINNET_RPC)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "query",
+            "params": {
+                "request_type": "view_account",
+                "finality": "final",
+                "account_id": account_id
+            }
+        }))
+        .send()
+        .await?
+        .json()
+        .await?;
+    response["result"]["storage_usage"]
+        .as_u64()
+        .ok_or_else(|| "Missing storage_usage in view_account response".into())
+}
+
+pub async fn fetch_mainnet_code(
+    client: &reqwest::Client,
+    account_id: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let response: serde_json::Value = client
+        .post(MAINNET_RPC)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "query",
+            "params": {
+                "request_type": "view_code",
+                "finality": "final",
+                "account_id": account_id
+            }
+        }))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let code_base64 = response["result"]["code_base64"]
+        .as_str()
+        .ok_or("Missing code_base64 in response")?;
+    Ok(base64::engine::general_purpose::STANDARD.decode(code_base64)?)
+}
+
+/// Fetch all contract state from mainnet using INTEAR's paginated `view_state` extension.
+pub async fn fetch_mainnet_state(
+    client: &reqwest::Client,
+    account_id: &str,
+) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Box<dyn std::error::Error>> {
+    let b64 = base64::engine::general_purpose::STANDARD;
+    let mut all_state: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    let mut cursor: Option<String> = None;
+
+    loop {
+        let params = if let Some(ref c) = cursor {
+            json!({
+                "request_type": "INTEAR_paginated_view_state",
+                "finality": "final",
+                "account_id": account_id,
+                "prefix_base64": "",
+                "cursor_base64": c
+            })
+        } else {
+            json!({
+                "request_type": "INTEAR_paginated_view_state",
+                "finality": "final",
+                "account_id": account_id,
+                "prefix_base64": ""
+            })
+        };
+
+        let response: serde_json::Value = client
+            .post(MAINNET_RPC)
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "query",
+                "params": params
+            }))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        let result = &response["result"];
+        let values = result["values"]
+            .as_array()
+            .ok_or("Missing values in paginated state response")?;
+
+        for item in values {
+            let key = b64.decode(item["key"].as_str().unwrap())?;
+            let value = b64.decode(item["value"].as_str().unwrap())?;
+            all_state.push((key, value));
+        }
+
+        match result.get("next_cursor") {
+            Some(serde_json::Value::String(next)) => cursor = Some(next.clone()),
+            _ => break,
+        }
+    }
+
+    println!(
+        "Fetched {} state entries from {account_id}",
+        all_state.len()
+    );
+    Ok(all_state)
+}
+
+/// Pull a mainnet contract (code + every state entry) into the sandbox and attach a fresh
+/// full-access key so the test can sign transactions for it.
+pub async fn patch_mainnet_contract(
+    sandbox: &Worker<Sandbox>,
+    client: &reqwest::Client,
+    account_id_str: &str,
+) -> Result<Contract, Box<dyn std::error::Error>> {
+    let account_id: AccountId = account_id_str.parse()?;
+    let code = fetch_mainnet_code(client, account_id_str).await?;
+    let state = fetch_mainnet_state(client, account_id_str).await?;
+    let storage_usage = fetch_mainnet_storage_usage(client, account_id_str).await?;
+    let sk = SecretKey::from_seed(KeyType::ED25519, account_id_str);
+
+    sandbox
+        .patch(&account_id)
+        .account(
+            AccountDetailsPatch::default()
+                .balance(NearToken::from_near(100))
+                .storage_usage(storage_usage),
+        )
+        .access_key(sk.public_key(), AccessKey::full_access())
+        .code(&code)
+        .states(state.iter().map(|(k, v)| (k.as_slice(), v.as_slice())))
+        .transact()
+        .await?;
+
+    Ok(Contract::from_secret_key(account_id, sk, sandbox))
+}
+
+/// Patch a plain NEAR account (no contract) into existence so the test can sign as it.
+pub async fn patch_account(
+    sandbox: &Worker<Sandbox>,
+    account_id_str: &str,
+    balance: NearToken,
+) -> Result<Account, Box<dyn std::error::Error>> {
+    let account_id: AccountId = account_id_str.parse()?;
+    let sk = SecretKey::from_seed(KeyType::ED25519, account_id_str);
+    sandbox
+        .patch(&account_id)
+        .account(AccountDetailsPatch::default().balance(balance))
+        .access_key(sk.public_key(), AccessKey::full_access())
+        .transact()
+        .await?;
+    Ok(Account::from_secret_key(account_id, sk, sandbox))
+}

--- a/integration-tests/tests/setup/mod.rs
+++ b/integration-tests/tests/setup/mod.rs
@@ -1,3 +1,4 @@
+pub mod mainnet;
 pub mod venear_helpers;
 pub mod voting_helpers;
 

--- a/integration-tests/tests/test_contracts_upgrade.rs
+++ b/integration-tests/tests/test_contracts_upgrade.rs
@@ -1,678 +1,162 @@
 mod setup;
 
-use crate::setup::{VENEAR_WASM_FILEPATH, VOTING_WASM_FILEPATH};
-use base64::Engine;
-use near_sdk::{Gas, NearToken};
+use crate::setup::VENEAR_WASM_FILEPATH;
+use crate::setup::mainnet::{patch_account, patch_mainnet_contract};
+use common::account::Account as VenearAccount;
+use common::{Bps, near_add};
+use near_sdk::{AccountId, Gas, NearToken};
 use near_workspaces::network::Sandbox;
-use near_workspaces::types::{KeyType, SecretKey};
-use near_workspaces::{AccessKey, Account, AccountDetailsPatch, AccountId, Contract, Worker};
+use near_workspaces::{Account, Contract, Worker};
 use serde_json::json;
+use std::collections::HashMap;
 
-const MAINNET_RPC: &str = "https://rpc.intea.rs";
-const VOTING_ID: &str = "vote.dao";
 const VENEAR_ID: &str = "venear.dao";
-/// Both production contracts are owned by the same Sputnik DAO root account, so a single
-/// patched sandbox account stands in for the owner of both during this end-to-end test.
-const SHARED_OWNER_ID: &str = "hos-root.sputnik-dao.near";
 
-const DAY_NS: u64 = 24 * 60 * 60 * 1_000_000_000;
+/// Mainnet account with failing set_delegators.
+const MISALIGNED_DELEGATOR: &str = "yuensid.near";
 
-async fn fetch_mainnet_code(
-    client: &reqwest::Client,
-    account_id: &str,
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let response: serde_json::Value = client
-        .post(MAINNET_RPC)
-        .json(&json!({
-            "jsonrpc": "2.0",
-            "id": "1",
-            "method": "query",
-            "params": {
-                "request_type": "view_code",
-                "finality": "final",
-                "account_id": account_id
-            }
-        }))
-        .send()
-        .await?
-        .json()
-        .await?;
-    let code_base64 = response["result"]["code_base64"]
-        .as_str()
-        .ok_or("Missing code_base64 in response")?;
-    Ok(base64::engine::general_purpose::STANDARD.decode(code_base64)?)
-}
+/// Growth-rate ceiling used to bound how much veNEAR an account can legitimately accrue between
+/// the pre- and post-upgrade voting-power sweeps.
+const MAX_ANNUAL_GROWTH_PERCENT: u128 = 100;
+const SEC_IN_YEAR: u128 = 365 * 24 * 3_600;
+/// Rounding slack per delegation in an account.
+const ROUNDING_SLACK: NearToken = NearToken::from_millinear(2);
 
-/// Fetch all contract state from mainnet using INTEAR's paginated `view_state` extension.
-async fn fetch_mainnet_state(
-    client: &reqwest::Client,
-    account_id: &str,
-) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Box<dyn std::error::Error>> {
-    let b64 = base64::engine::general_purpose::STANDARD;
-    let mut all_state: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
-    let mut cursor: Option<String> = None;
-
-    loop {
-        let params = if let Some(ref c) = cursor {
-            json!({
-                "request_type": "INTEAR_paginated_view_state",
-                "finality": "final",
-                "account_id": account_id,
-                "prefix_base64": "",
-                "cursor_base64": c
-            })
-        } else {
-            json!({
-                "request_type": "INTEAR_paginated_view_state",
-                "finality": "final",
-                "account_id": account_id,
-                "prefix_base64": ""
-            })
-        };
-
-        let response: serde_json::Value = client
-            .post(MAINNET_RPC)
-            .json(&json!({
-                "jsonrpc": "2.0",
-                "id": "1",
-                "method": "query",
-                "params": params
-            }))
-            .send()
+async fn fetch_accounts(
+    venear: &Contract,
+) -> Result<Vec<VenearAccount>, Box<dyn std::error::Error>> {
+    let num_accounts: u32 = venear.view("get_num_accounts").await?.json()?;
+    let mut accounts: Vec<VenearAccount> = vec![];
+    while u32::try_from(accounts.len()).unwrap() < num_accounts {
+        let batch: Vec<serde_json::Value> = venear
+            .view("get_accounts")
+            .args_json(json!({ "from_index": accounts.len(), "limit": 500u32 }))
             .await?
-            .json()
-            .await?;
-
-        let result = &response["result"];
-        let values = result["values"]
-            .as_array()
-            .ok_or("Missing values in paginated state response")?;
-
-        for item in values {
-            let key = b64.decode(item["key"].as_str().unwrap())?;
-            let value = b64.decode(item["value"].as_str().unwrap())?;
-            all_state.push((key, value));
-        }
-
-        match result.get("next_cursor") {
-            Some(serde_json::Value::String(next)) => cursor = Some(next.clone()),
-            _ => break,
+            .json()?;
+        for info in batch {
+            accounts.push(serde_json::from_value(info["account"].clone())?);
         }
     }
+    Ok(accounts)
+}
 
-    println!(
-        "Fetched {} state entries from {account_id}",
-        all_state.len()
+/// Voting power under the deployed v1.1.0 formula.
+fn legacy_voting_power(account: &VenearAccount) -> NearToken {
+    let self_bps = Bps::new(10_000_u16.saturating_sub(account.delegated_bps()));
+    let retained = near_add(
+        self_bps * account.balance.near_balance,
+        self_bps * account.balance.extra_venear_balance,
     );
-    Ok(all_state)
+    near_add(account.delegated_balance.total(), retained)
 }
 
-/// Pull a mainnet contract (code + every state entry) into the sandbox and attach a fresh
-/// full-access key so the test can sign transactions for it.
-async fn patch_mainnet_contract(
-    sandbox: &Worker<Sandbox>,
-    client: &reqwest::Client,
-    account_id_str: &str,
-) -> Result<Contract, Box<dyn std::error::Error>> {
-    let account_id: AccountId = account_id_str.parse()?;
-    let code = fetch_mainnet_code(client, account_id_str).await?;
-    let state = fetch_mainnet_state(client, account_id_str).await?;
-    let sk = SecretKey::from_seed(KeyType::ED25519, account_id_str);
-
-    sandbox
-        .patch(&account_id)
-        .account(AccountDetailsPatch::default().balance(NearToken::from_near(100)))
-        .access_key(sk.public_key(), AccessKey::full_access())
-        .code(&code)
-        .states(state.iter().map(|(k, v)| (k.as_slice(), v.as_slice())))
-        .transact()
-        .await?;
-
-    Ok(Contract::from_secret_key(account_id, sk, sandbox))
-}
-
-/// Patch an empty NEAR account (no contract) into existence so the test can sign as it.
-/// Used for the production owner / a sandbox reviewer / a sandbox proposer.
-async fn patch_account(
-    sandbox: &Worker<Sandbox>,
-    account_id_str: &str,
-    balance: NearToken,
-) -> Result<Account, Box<dyn std::error::Error>> {
-    let account_id: AccountId = account_id_str.parse()?;
-    let sk = SecretKey::from_seed(KeyType::ED25519, account_id_str);
-    sandbox
-        .patch(&account_id)
-        .account(AccountDetailsPatch::default().balance(balance))
-        .access_key(sk.public_key(), AccessKey::full_access())
-        .transact()
-        .await?;
-    Ok(Account::from_secret_key(account_id, sk, sandbox))
-}
-
-async fn create_classic_proposal(
-    voting: &Contract,
-    proposer: &Account,
-) -> Result<u32, Box<dyn std::error::Error>> {
-    let outcome = proposer
-        .call(voting.id(), "create_proposal")
-        .args_json(json!({
-            "metadata": {
-                "title": "Upgrade smoke test",
-                "description": "Created post-upgrade to verify voting <-> venear cross-contract calls.",
-            },
-            "actions": serde_json::Value::Null,
-            "flow": "Classic",
-        }))
-        .deposit(NearToken::from_near(2))
-        .gas(Gas::from_tgas(50))
-        .transact()
-        .await?;
-    if !outcome.is_success() {
-        return Err(format!(
-            "create_proposal (Classic) failed: {:#?}",
-            outcome.outcomes()
-        )
-        .into());
-    }
-    Ok(outcome.json()?)
-}
-
-async fn create_fst_proposal(
-    voting: &Contract,
-    proposer: &Account,
-) -> Result<u32, Box<dyn std::error::Error>> {
-    // FastTrack requires `bond_amount` (100 NEAR after migration) + `base_proposal_fee` + storage.
-    let outcome = proposer
-        .call(voting.id(), "create_proposal")
-        .args_json(json!({
-            "metadata": {
-                "title": "Upgrade smoke test (FastTrack)",
-                "description": "Created post-upgrade to verify the FastTrack flow against new venear.",
-            },
-            "actions": serde_json::Value::Null,
-            "flow": "FastTrack",
-        }))
-        .deposit(NearToken::from_near(101))
-        .gas(Gas::from_tgas(50))
-        .transact()
-        .await?;
-    if !outcome.is_success() {
-        return Err(format!(
-            "create_proposal (FastTrack) failed: {:#?}",
-            outcome.outcomes()
-        )
-        .into());
-    }
-    Ok(outcome.json()?)
-}
-
-async fn approve_classic(
-    voting: &Contract,
-    reviewer: &Account,
-    proposal_id: u32,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let outcome = reviewer
-        .call(voting.id(), "approve_proposal")
-        .args_json(json!({
-            "proposal_id": proposal_id,
-            "majority_type": serde_json::Value::Null,
-        }))
-        .deposit(NearToken::from_yoctonear(1))
-        .gas(Gas::from_tgas(200))
-        .transact()
-        .await?;
-    if !outcome.is_success() {
-        return Err(format!(
-            "approve_proposal (Classic) failed: {:#?}",
-            outcome.outcomes()
-        )
-        .into());
-    }
-    Ok(())
-}
-
-async fn approve_fst(
-    voting: &Contract,
-    reviewer: &Account,
-    proposal_id: u32,
-    majority: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let outcome = reviewer
-        .call(voting.id(), "approve_proposal")
-        .args_json(json!({
-            "proposal_id": proposal_id,
-            "majority_type": majority,
-        }))
-        .deposit(NearToken::from_yoctonear(1))
-        .gas(Gas::from_tgas(200))
-        .transact()
-        .await?;
-    if !outcome.is_success() {
-        return Err(format!(
-            "approve_proposal (FastTrack) failed: {:#?}",
-            outcome.outcomes()
-        )
-        .into());
-    }
-    Ok(())
-}
-
-/// Pick the highest-balance mainnet veNEAR holders directly from the (patched-in) venear
-/// merkle tree, patch them into the sandbox with our own signing keys, and return their
-/// account handles. Doing it dynamically keeps the test from depending on a specific
-/// mainnet account ID that may churn over time.
-async fn patch_mainnet_voters(
-    sandbox: &Worker<Sandbox>,
+/// Calls `set_delegations(entries)` as `delegator`. `Err` carries the contract's panic message.
+async fn set_delegations(
+    delegator: &Account,
     venear: &Contract,
-    count: usize,
-) -> Result<Vec<Account>, Box<dyn std::error::Error>> {
-    let accounts: Vec<serde_json::Value> = venear
-        .view("get_accounts")
-        .args_json(json!({ "from_index": 0u32, "limit": 50u32 }))
-        .await?
-        .json()?;
-    // An account's *votable* balance is `delegated_balance + own_balance * self_bps`. Anyone who
-    // has delegated 100% of their voting power out (v1.0.1 stores this as a non-null `delegation`
-    // entry; v1 partials show up as `delegations: [...]`) contributes 0 from their own balance.
-    // Filter those out so we never try to vote from an account whose effective balance is zero.
-    let mut ranked: Vec<(u128, String)> = accounts
-        .iter()
-        .filter_map(|info| {
-            let account = &info["account"];
-            let id = account["account_id"].as_str()?.to_string();
-            let delegated_out = !account["delegation"].is_null()
-                || account["delegations"]
-                    .as_array()
-                    .map(|d| !d.is_empty())
-                    .unwrap_or(false);
-            if delegated_out {
-                return None;
-            }
-            let own_near: u128 = account["balance"]["near_balance"].as_str()?.parse().ok()?;
-            let incoming_near: u128 = account["delegated_balance"]["near_balance"]
-                .as_str()?
-                .parse()
-                .ok()?;
-            let total = own_near.checked_add(incoming_near)?;
-            if total == 0 {
-                return None;
-            }
-            Some((total, id))
+    entries: &serde_json::Value,
+) -> Result<Result<(), String>, Box<dyn std::error::Error>> {
+    let outcome = delegator
+        .call(venear.id(), "set_delegations")
+        .args_json(json!({ "entries": entries }))
+        .deposit(NearToken::from_millinear(50))
+        .gas(Gas::from_tgas(100))
+        .transact()
+        .await?;
+    if outcome.is_success() {
+        return Ok(Ok(()));
+    }
+    Ok(Err(outcome
+        .receipt_failures()
+        .into_iter()
+        // Debug, not Display: only the former carries the contract's panic message.
+        .map(|failure| match failure.to_owned().into_result() {
+            Err(err) => format!("{err:?}"),
+            Ok(value) => format!("unexpected success: {value:?}"),
         })
-        .collect();
-    ranked.sort_by(|a, b| b.0.cmp(&a.0));
-
-    let mut voters = Vec::new();
-    for (_, id) in ranked.into_iter().take(count) {
-        voters.push(patch_account(sandbox, &id, NearToken::from_near(5)).await?);
-    }
-    if voters.len() < count {
-        return Err(format!(
-            "Expected {count} mainnet voters but only resolved {}",
-            voters.len()
-        )
-        .into());
-    }
-    Ok(voters)
-}
-
-async fn cast_vote(
-    venear: &Contract,
-    voting: &Contract,
-    voter: &Account,
-    proposal_id: u32,
-    option: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let (merkle_proof, v_account): (serde_json::Value, serde_json::Value) = venear
-        .view("get_proof")
-        .args_json(json!({ "account_id": voter.id() }))
-        .await?
-        .json()?;
-    let outcome = voter
-        .call(voting.id(), "vote")
-        .args_json(json!({
-            "proposal_id": proposal_id,
-            "vote": option,
-            "merkle_proof": merkle_proof,
-            "v_account": v_account,
-        }))
-        .deposit(NearToken::from_millinear(15))
-        .gas(Gas::from_tgas(50))
-        .transact()
-        .await?;
-    if !outcome.is_success() {
-        return Err(format!(
-            "vote({option}) by {} on #{proposal_id} failed: {:#?}",
-            voter.id(),
-            outcome.outcomes()
-        )
-        .into());
-    }
-    Ok(())
+        .collect::<Vec<_>>()
+        .join("; ")))
 }
 
 #[tokio::test]
 #[ignore]
-/// To run this test: `cargo test test_contracts_upgrade -- --ignored --nocapture`
+/// To run this test: `cargo test test_venear_upgrade -- --ignored --nocapture`
 ///
-/// End-to-end migration safety check against live mainnet state for both governance contracts:
-///   1. Pull `vote.dao` and `venear.dao` code+state from mainnet into the sandbox.
-///   2. Upgrade voting first; confirm `migrate_state()` preserved its config and proposals.
-///   3. Drive a fresh Classic proposal through `create_proposal` + `approve_proposal` so the
-///      upgraded voting must call `get_snapshot()` on the still-legacy venear — proves the
-///      partial-upgrade window (voting only) keeps working.
-///   4. Upgrade venear; confirm `migrate_state()` preserved its config and backfilled
-///      `max_delegations` to the legacy default.
-///   5. Drive a second proposal end-to-end so the upgraded voting talks to the upgraded venear.
-async fn test_contracts_upgrade() -> Result<(), Box<dyn std::error::Error>> {
-    let sandbox = near_workspaces::sandbox().await?;
+/// Upgrade safety check for the venear delegation-pool migration against live mainnet state.
+///   1. Pull `venear.dao` code + state from mainnet into the sandbox, record every account's
+///      voting power, and confirm yuensid.near cannot clear its delegation on the deployed code.
+///   2. Upgrade venear. `migrate_state()` recomputes every delegation pool from the exact
+///      `delegation_contribution` formula; v1.1.0 credited pools with a bps-scaled amount whose
+///      rounding drifts as veNEAR grows, so subtracting a delegation could underflow the pool.
+///   3. Every account's voting power must survive the migration unchanged, up to veNEAR growth
+///      between the two sweeps plus a milliNEAR or so of rounding per delegation.
+///   4. yuensid.near, stuck before the upgrade, can now clear its delegation set and restore it.
+async fn test_venear_upgrade() -> Result<(), Box<dyn std::error::Error>> {
+    let sandbox: Worker<Sandbox> = near_workspaces::sandbox().await?;
     let client = reqwest::Client::new();
 
     // Mainnet snapshot in sandbox.
-    let voting = patch_mainnet_contract(&sandbox, &client, VOTING_ID).await?;
     let venear = patch_mainnet_contract(&sandbox, &client, VENEAR_ID).await?;
-    let owner = patch_account(&sandbox, SHARED_OWNER_ID, NearToken::from_near(1_000)).await?;
+    let old_config: serde_json::Value = venear.view("get_config").await?.json()?;
+    let owner = patch_account(
+        &sandbox,
+        old_config["owner_account_id"].as_str().unwrap(),
+        NearToken::from_near(1_000),
+    )
+    .await?;
 
-    // Baseline: confirm we're testing against the expected pre-upgrade versions.
-    let old_voting_version: String = voting.view("get_version").await?.json()?;
-    let old_venear_version: String = venear.view("get_version").await?.json()?;
+    // Baseline: confirm we're testing against the expected pre-upgrade version.
+    let old_version: String = venear.view("get_version").await?.json()?;
     assert_eq!(
-        old_voting_version, "1.0.3",
-        "Mainnet voting should be on v1.0.3 — the baseline migrate_state() upgrades from",
+        old_version, "1.1.0",
+        "Mainnet venear should be on v1.1.0 — the legacy-delegation-formula baseline",
     );
-    assert_eq!(
-        old_venear_version, "1.0.1",
-        "Mainnet venear should be on v1.0.1 — the baseline migrate_state() upgrades from",
-    );
-
-    let old_voting_config: serde_json::Value = voting.view("get_config").await?.json()?;
-    let old_venear_config: serde_json::Value = venear.view("get_config").await?.json()?;
-    let num_proposals_before: u32 = voting.view("get_num_proposals").await?.json()?;
-
-    // Sanity-check that the live v1.0.3 voting config still carries every field
-    // `migrate_state()` reads off of `OldConfig` — if mainnet ever rotates onto a
-    // different layout, this test must fail loudly rather than silently skip work.
-    for field in [
-        "venear_account_id",
-        "reviewer_ids",
-        "council_ids",
-        "owner_account_id",
-        "voting_duration_ns",
-        "timelock_duration_ns",
-        "base_proposal_fee",
-        "vote_storage_fee",
-        "guardians",
-        "proposal_expiration_ns",
-        "proposed_new_owner_account_id",
-        "quorum_threshold_bps",
-        "quorum_floor",
-        "approval_threshold_bps",
-    ] {
-        assert!(
-            old_voting_config.get(field).is_some(),
-            "v1.0.3 voting config missing expected field `{field}`: {old_voting_config:#}",
-        );
-    }
-    assert_eq!(
-        old_voting_config["owner_account_id"].as_str().unwrap(),
-        SHARED_OWNER_ID,
-        "Test assumes vote.dao is owned by the patched sandbox owner",
-    );
-    assert_eq!(
-        old_venear_config["owner_account_id"].as_str().unwrap(),
-        SHARED_OWNER_ID,
-        "Test assumes venear.dao is owned by the patched sandbox owner",
-    );
-
-    // Capture the legacy proposals' JSON straight off the live v1.0.3 contract so that, after the
-    // upgrade, we can diff each migrated proposal field-by-field against its pre-migration value.
-    let old_proposals: Vec<serde_json::Value> = voting
-        .view("get_proposals")
-        .args_json(json!({ "from_index": 0u32, "limit": num_proposals_before }))
-        .await?
-        .json()?;
 
     // ============================================================
-    // Phase 1: upgrade voting only.
+    // Phase 1: pre-upgrade baseline — the whole merkle tree, and every account's voting power
+    // under the formula the deployed v1.1.0 uses.
     // ============================================================
-    let voting_wasm = std::fs::read(VOTING_WASM_FILEPATH)?;
-    let outcome = owner
-        .call(voting.id(), "upgrade")
-        .args(voting_wasm)
-        .gas(Gas::from_tgas(100))
-        .transact()
-        .await?;
-    assert!(
-        outcome.is_success(),
-        "Failed to upgrade voting contract: {:#?}",
-        outcome.outcomes()
-    );
+    let old_accounts = fetch_accounts(&venear).await?;
+    let old_powers: Vec<NearToken> = old_accounts.iter().map(legacy_voting_power).collect();
 
-    let new_voting_version: String = voting.view("get_version").await?.json()?;
-    assert_eq!(
-        new_voting_version,
-        env!("CARGO_PKG_VERSION"),
-        "Post-upgrade voting version should match the local workspace version",
-    );
-
-    let new_voting_config: serde_json::Value = voting.view("get_config").await?.json()?;
-
-    // Fields carried verbatim from v1.0.3's `OldConfig` by `migrate_state()`.
-    for field in [
-        "venear_account_id",
-        "reviewer_ids",
-        "council_ids",
-        "owner_account_id",
-        "base_proposal_fee",
-        "vote_storage_fee",
-        "guardians",
-        "proposed_new_owner_account_id",
-        "quorum_threshold_bps",
-        "quorum_floor",
-        "approval_threshold_bps",
-    ] {
-        assert_eq!(
-            new_voting_config[field], old_voting_config[field],
-            "Voting field `{field}` was not preserved by migrate_state()",
-        );
-    }
-
-    // Durations + merged-flow defaults seeded by migrate_state().
-    assert_eq!(
-        new_voting_config["timelock_duration_ns"],
-        (14 * DAY_NS).to_string()
-    );
-    assert_eq!(
-        new_voting_config["classic_proposal_expiration_ns"],
-        (7 * DAY_NS).to_string()
-    );
-    assert_eq!(
-        new_voting_config["fast_track_proposal_expiration_ns"],
-        (2 * DAY_NS).to_string()
-    );
-    assert_eq!(
-        new_voting_config["classic_voting_duration_ns"],
-        (14 * DAY_NS).to_string()
-    );
-    assert_eq!(
-        new_voting_config["fast_track_voting_duration_ns"],
-        (5 * DAY_NS).to_string()
-    );
-    assert_eq!(new_voting_config["simple_majority_threshold_bps"], 5000);
-    assert_eq!(new_voting_config["strong_majority_threshold_bps"], 6667);
-    assert_eq!(
-        new_voting_config["sandbox_duration_ns"],
-        (7 * DAY_NS).to_string()
-    );
-    assert_eq!(new_voting_config["sandbox_threshold_bps"], 3000);
-    assert_eq!(
-        new_voting_config["bond_amount"],
-        json!(NearToken::from_near(100))
-    );
-    assert_eq!(new_voting_config["treasury_account_id"], "norfolks.near");
-    assert_eq!(new_voting_config["max_active_proposals"], 3);
-
-    let num_proposals_after: u32 = voting.view("get_num_proposals").await?.json()?;
-    assert_eq!(
-        num_proposals_after, num_proposals_before,
-        "Proposal count must not change across the voting upgrade",
-    );
-
-    // Verify migration is correct
-    let migrated_proposals: Vec<serde_json::Value> = voting
-        .view("get_proposals")
-        .args_json(json!({ "from_index": 0u32, "limit": num_proposals_before }))
-        .await?
-        .json()?;
-    assert_eq!(
-        u32::try_from(migrated_proposals.len()).unwrap(),
-        num_proposals_before,
-        "Every legacy proposal must remain fetchable after migrate_state()",
-    );
-    for (idx, (old, new)) in old_proposals
+    let num_delegators = old_accounts
         .iter()
-        .zip(migrated_proposals.iter())
-        .enumerate()
-    {
-        // Fields the migration must carry over verbatim from the v1.0.3 proposal (+ its metadata).
-        // `status` is deliberately excluded: both contracts re-`update()` on read against the
-        // current block time, so it can legitimately differ between the two reads.
-        for field in [
-            "id",
-            "creation_time_ns",
-            "proposer_id",
-            "reviewer_id",
-            "rejecter_id",
-            "voting_start_time_ns",
-            "voting_duration_ns",
-            "timelock_duration_ns",
-            "expiration_ns",
-            "snapshot_and_state",
-            "votes",
-            "total_votes",
-            "quorum_threshold_bps",
-            "quorum_floor",
-            "approval_threshold_bps",
-            "actions",
-            "title",
-            "description",
-        ] {
-            assert_eq!(
-                new[field], old[field],
-                "Migrated proposal {idx} field `{field}` was not preserved by migrate_state()\n\
-                 old: {old:#}\nnew: {new:#}",
-            );
+        .filter(|account| !account.delegations.is_empty())
+        .count();
+    let stuck = old_accounts
+        .iter()
+        .find(|account| account.account_id.as_str() == MISALIGNED_DELEGATOR)
+        .cloned()
+        .unwrap_or_else(|| {
+            panic!("{MISALIGNED_DELEGATOR} should be registered in the imported mainnet state")
+        });
+    println!(
+        "Mainnet venear state: {} accounts, {num_delegators} of them delegating; the pinned \
+         regression case {MISALIGNED_DELEGATOR} delegates {:?}",
+        old_accounts.len(),
+        stuck.delegations,
+    );
+
+    // Verify yuensid.near can't change delegators.
+    let stuck_account =
+        patch_account(&sandbox, MISALIGNED_DELEGATOR, NearToken::from_near(2)).await?;
+    let cleared = json!([]);
+    let failure = match set_delegations(&stuck_account, &venear, &cleared).await? {
+        Err(failure) => failure,
+        Ok(()) => {
+            panic!("set_delegations([]) by {MISALIGNED_DELEGATOR} succeeded before the upgrade")
         }
-        assert_eq!(
-            new["id"].as_u64().unwrap(),
-            u64::try_from(idx).unwrap(),
-            "Migrated proposal {idx} should keep its index as `id`: {new:#}",
-        );
-        // New merged-flow fields the migration seeds onto every legacy (Classic) proposal.
-        assert_eq!(
-            new["flow"], "Classic",
-            "migrate_state() rewrites every legacy proposal with flow=Classic: {new:#}",
-        );
-        assert_eq!(
-            new["approval_time_ns"], old["voting_start_time_ns"],
-            "Legacy proposal {idx} should backfill approval_time_ns from voting_start_time_ns: {new:#}",
-        );
-        assert!(
-            new["sandbox_start_time_ns"].is_null(),
-            "Legacy proposal {idx} should have no sandbox_start_time_ns: {new:#}",
-        );
-        assert_eq!(
-            new["bond_amount"], "0",
-            "Legacy proposal {idx} should carry a zero bond: {new:#}",
-        );
-        assert_eq!(
-            new["sandbox_duration_ns"], "0",
-            "Legacy proposal {idx} should carry a zero sandbox duration: {new:#}",
-        );
-        assert_eq!(
-            new["sandbox_threshold_bps"], 0,
-            "Legacy proposal {idx} should carry a zero sandbox threshold: {new:#}",
-        );
-    }
+    };
+    println!("Pre-upgrade: {MISALIGNED_DELEGATOR} cannot clear its delegations: {failure}");
 
     // ============================================================
-    // Phase 2: new voting + OLD venear.
-    //
-    // Approving a proposal triggers against the legacy v1.0.1 venear.
-    // ============================================================
-
-    // Add a sandbox reviewer through governance so we can drive `approve_proposal` ourselves.
-    let reviewer = patch_account(&sandbox, "reviewer.test", NearToken::from_near(10)).await?;
-    let mut reviewers: Vec<AccountId> =
-        serde_json::from_value(new_voting_config["reviewer_ids"].clone())?;
-    reviewers.push(reviewer.id().clone());
-    owner
-        .call(voting.id(), "set_reviewer_ids")
-        .args_json(json!({ "reviewer_ids": reviewers }))
-        .deposit(NearToken::from_yoctonear(1))
-        .transact()
-        .await?
-        .into_result()?;
-
-    // Big balance: covers a FastTrack 100 NEAR bond + a few Classic fees with room to spare.
-    let proposer = patch_account(&sandbox, "proposer.test", NearToken::from_near(250)).await?;
-    // Pull a few real mainnet veNEAR holders into the sandbox so we can sign vote() calls as them.
-    let voters = patch_mainnet_voters(&sandbox, &venear, 3).await?;
-
-    let pid_old_classic = create_classic_proposal(&voting, &proposer).await?;
-    approve_classic(&voting, &reviewer, pid_old_classic).await?;
-
-    let proposal: serde_json::Value = voting
-        .view("get_proposal")
-        .args_json(json!({ "proposal_id": pid_old_classic }))
-        .await?
-        .json()?;
-    assert!(
-        proposal["snapshot_and_state"].is_object(),
-        "snapshot_and_state must be populated by the cross-contract call into the OLD venear: \
-         {proposal:#}",
-    );
-    assert_eq!(
-        proposal["status"], "Voting",
-        "Approved proposal should land in Voting status once the snapshot promise resolves",
-    );
-
-    // Cast a vote from each patched voter so we exercise vote() against the old venear's
-    // merkle root (proof is verified inside the voting contract using the snapshot we just stored).
-    cast_vote(&venear, &voting, &voters[0], pid_old_classic, "For").await?;
-    cast_vote(&venear, &voting, &voters[1], pid_old_classic, "Against").await?;
-    cast_vote(&venear, &voting, &voters[2], pid_old_classic, "Abstain").await?;
-
-    let proposal: serde_json::Value = voting
-        .view("get_proposal")
-        .args_json(json!({ "proposal_id": pid_old_classic }))
-        .await?
-        .json()?;
-    assert_eq!(
-        proposal["votes"][0]["total_votes"], 1,
-        "one For vote landed"
-    );
-    assert_eq!(
-        proposal["votes"][1]["total_votes"], 1,
-        "one Against vote landed"
-    );
-    assert_eq!(
-        proposal["votes"][2]["total_votes"], 1,
-        "one Abstain vote landed"
-    );
-    assert_eq!(
-        proposal["total_votes"]["total_votes"], 3,
-        "total_votes should be the sum across all three options",
-    );
-
-    // ============================================================
-    // Phase 3: upgrade venear.
+    // Phase 2: upgrade venear.
     // ============================================================
     let venear_wasm = std::fs::read(VENEAR_WASM_FILEPATH)?;
     let outcome = owner
         .call(venear.id(), "upgrade")
         .args(venear_wasm)
-        .gas(Gas::from_tgas(100))
+        .gas(Gas::from_tgas(300))
         .transact()
         .await?;
     assert!(
@@ -680,183 +164,141 @@ async fn test_contracts_upgrade() -> Result<(), Box<dyn std::error::Error>> {
         "Failed to upgrade venear contract: {:#?}",
         outcome.outcomes()
     );
+    println!(
+        "venear upgrade burnt {} TGas total, heaviest receipt burnt {} TGas",
+        outcome.total_gas_burnt.as_tgas(),
+        outcome
+            .outcomes()
+            .iter()
+            .map(|o| o.gas_burnt.as_tgas())
+            .max()
+            .unwrap()
+    );
 
-    let new_venear_version: String = venear.view("get_version").await?.json()?;
+    let new_version: String = venear.view("get_version").await?.json()?;
     assert_eq!(
-        new_venear_version,
+        new_version,
         env!("CARGO_PKG_VERSION"),
         "Post-upgrade venear version should match the local workspace version",
     );
+    // v1.1.0 already has the current config layout, so migrate_state() is an identity migration.
+    let new_config: serde_json::Value = venear.view("get_config").await?.json()?;
+    assert_eq!(
+        new_config, old_config,
+        "Venear config must be preserved verbatim by migrate_state()",
+    );
 
-    let new_venear_config: serde_json::Value = venear.view("get_config").await?.json()?;
-    for field in [
-        "lockup_contract_config",
-        "unlock_duration_ns",
-        "staking_pool_whitelist_account_id",
-        "lockup_code_deployers",
-        "local_deposit",
-        "min_lockup_deposit",
-        "owner_account_id",
-        "guardians",
-        "proposed_new_owner_account_id",
-    ] {
-        assert_eq!(
-            new_venear_config[field], old_venear_config[field],
-            "Venear field `{field}` was not preserved by migrate_state()",
-        );
+    // ============================================================
+    // Phase 3: voting power must survive the migration. The pools were rewritten and the formula
+    // that reads them replaced, so every account is re-measured with the post-upgrade
+    // `owned_total()` and compared against its v1.1.0 baseline.
+    // ============================================================
+    let new_accounts = fetch_accounts(&venear).await?;
+    assert_eq!(
+        new_accounts.len(),
+        old_accounts.len(),
+        "migrate_state() must not add or drop accounts",
+    );
+
+    // How many delegations feed each account's pool. The new formula truncates every incoming
+    // delegation's near share to whole milliNEAR and leaves the remainder with its owner, so a
+    // pool's rounding error grows with the number of delegators behind it.
+    let mut incoming: HashMap<&AccountId, u128> = HashMap::new();
+    for account in &old_accounts {
+        for delegation in &account.delegations {
+            *incoming.entry(&delegation.account_id).or_default() += 1;
+        }
     }
-    // `max_delegations` is the only field migrate_state() adds — it backfills the legacy default.
-    assert_eq!(new_venear_config["max_delegations"], 8);
+
+    let mut max_drift = (0u128, String::new());
+    for ((old_account, old), new_account) in old_accounts.iter().zip(&old_powers).zip(&new_accounts)
+    {
+        let account_id = &old_account.account_id;
+        assert_eq!(
+            account_id, &new_account.account_id,
+            "migrate_state() must not reorder the merkle tree",
+        );
+        assert_eq!(
+            old_account.delegations, new_account.delegations,
+            "migrate_state() must not touch the delegations of {account_id}",
+        );
+
+        let old = old.as_yoctonear();
+        let new = new_account.owned_total().as_yoctonear();
+        // Both sweeps are served by the contract, which grows each account to the timestamp of
+        // the block that served it — so the accounts themselves carry the exact window over which
+        // veNEAR legitimately accrued between the two readings.
+        let elapsed_sec =
+            u128::from(new_account.update_timestamp.0 - old_account.update_timestamp.0)
+                / 1_000_000_000;
+        let growth_bound = old * MAX_ANNUAL_GROWTH_PERCENT * elapsed_sec / (100 * SEC_IN_YEAR);
+        let delegations = incoming.get(account_id).copied().unwrap_or_default()
+            + u128::try_from(old_account.delegations.len()).unwrap();
+        let tolerance = growth_bound + (delegations + 1) * ROUNDING_SLACK.as_yoctonear();
+        let drift = old.abs_diff(new);
+        assert!(
+            drift <= tolerance,
+            "Voting power of {account_id} changed by {drift} yoctoNEAR across the migration \
+             ({old} -> {new}), more than the {tolerance} yoctoNEAR allowed for {elapsed_sec} s of \
+             growth plus rounding over its {delegations} delegations",
+        );
+        if drift > max_drift.0 {
+            max_drift = (drift, account_id.to_string());
+        }
+    }
+    println!(
+        "Voting power preserved for all {} accounts; largest drift {} yoctoNEAR, on {}",
+        old_accounts.len(),
+        max_drift.0,
+        max_drift.1,
+    );
 
     // ============================================================
-    // Phase 4: new voting + updated venear.
+    // Phase 4: the stuck delegator can change its delegations again.
     // ============================================================
 
-    let pid_new_classic = create_classic_proposal(&voting, &proposer).await?;
-    approve_classic(&voting, &reviewer, pid_new_classic).await?;
-
-    let proposal: serde_json::Value = voting
-        .view("get_proposal")
-        .args_json(json!({ "proposal_id": pid_new_classic }))
+    // The very call that underflowed under the legacy pool credits now goes through.
+    set_delegations(&stuck_account, &venear, &cleared)
         .await?
-        .json()?;
-    assert!(
-        proposal["snapshot_and_state"].is_object(),
-        "snapshot_and_state must be populated by the cross-contract call into the NEW venear: \
-         {proposal:#}",
-    );
-    assert_eq!(
-        proposal["status"], "Voting",
-        "Approved proposal should land in Voting status once the snapshot promise resolves",
-    );
-
-    cast_vote(&venear, &voting, &voters[0], pid_new_classic, "For").await?;
-    cast_vote(&venear, &voting, &voters[1], pid_new_classic, "Against").await?;
-    let proposal: serde_json::Value = voting
-        .view("get_proposal")
-        .args_json(json!({ "proposal_id": pid_new_classic }))
+        .map_err(|failure| {
+            format!(
+                "set_delegations([]) by the previously-stuck {MISALIGNED_DELEGATOR} still fails \
+                 after the upgrade: {failure}"
+            )
+        })?;
+    let info: serde_json::Value = venear
+        .view("get_account_info")
+        .args_json(json!({ "account_id": MISALIGNED_DELEGATOR }))
         .await?
         .json()?;
     assert_eq!(
-        proposal["votes"][0]["total_votes"], 1,
-        "Classic For vote landed"
-    );
-    assert_eq!(
-        proposal["votes"][1]["total_votes"], 1,
-        "Classic Against vote landed"
+        info["account"]["delegations"], cleared,
+        "{MISALIGNED_DELEGATOR} should have no delegations left after clearing them",
     );
 
-    // FastTrack flow: approve with a Simple majority and verify the proposal lands in Sandbox.
-    //
-    // Drop the sandbox graduation threshold to 1 bps so our handful of test voters can actually
-    // push the proposal past it — the production default of 30% would require us to control the
-    // majority of mainnet veNEAR, which isn't realistic in a sandbox. The threshold is captured
-    // onto the proposal at approval time, so this must happen before `approve_fst`.
-    owner
-        .call(voting.id(), "set_sandbox_threshold_bps")
-        .args_json(json!({ "sandbox_threshold_bps": 1u16 }))
-        .deposit(NearToken::from_yoctonear(1))
-        .transact()
+    // And it can delegate again: restore the original set.
+    let entries = serde_json::to_value(&stuck.delegations)?;
+    set_delegations(&stuck_account, &venear, &entries)
         .await?
-        .into_result()?;
-
-    let pid_new_fst = create_fst_proposal(&voting, &proposer).await?;
-    let fst_created: serde_json::Value = voting
-        .view("get_proposal")
-        .args_json(json!({ "proposal_id": pid_new_fst }))
+        .map_err(|failure| {
+            format!(
+                "restoring the delegations {:?} of the previously-stuck {MISALIGNED_DELEGATOR} \
+                 failed: {failure}",
+                stuck.delegations
+            )
+        })?;
+    let info: serde_json::Value = venear
+        .view("get_account_info")
+        .args_json(json!({ "account_id": MISALIGNED_DELEGATOR }))
         .await?
         .json()?;
     assert_eq!(
-        fst_created["bond_amount"],
-        json!(NearToken::from_near(100)),
-        "FastTrack proposal must hold the 100 NEAR bond until approval",
+        info["account"]["delegations"], entries,
+        "{MISALIGNED_DELEGATOR} should hold its original delegation set again",
     );
-
-    approve_fst(&voting, &reviewer, pid_new_fst, "Simple").await?;
-
-    let fst_approved: serde_json::Value = voting
-        .view("get_proposal")
-        .args_json(json!({ "proposal_id": pid_new_fst }))
-        .await?
-        .json()?;
-    assert_eq!(
-        fst_approved["status"], "Sandbox",
-        "FastTrack proposal should land in Sandbox after approval",
-    );
-    assert!(
-        fst_approved["snapshot_and_state"].is_object(),
-        "FastTrack approval must also snapshot from the upgraded venear: {fst_approved:#}",
-    );
-    assert_eq!(
-        fst_approved["bond_amount"],
-        json!(NearToken::from_yoctonear(0)),
-        "Bond must be forwarded to the treasury once approved",
-    );
-
-    // Only "For" votes are allowed during the Sandbox window — exercise that path. With the
-    // sandbox threshold dropped to 1 bps, this single `For` vote also crosses the graduation
-    // threshold, so the proposal must flip Sandbox → Scheduled inline (the contract re-checks the
-    // threshold on every vote). A follow-up vote in Scheduled status would fail (only Sandbox /
-    // Voting accept votes), so we stop after one and assert the transition.
-    cast_vote(&venear, &voting, &voters[0], pid_new_fst, "For").await?;
-    let fst_after_vote: serde_json::Value = voting
-        .view("get_proposal")
-        .args_json(json!({ "proposal_id": pid_new_fst }))
-        .await?
-        .json()?;
-    assert_eq!(
-        fst_after_vote["votes"][0]["total_votes"], 1,
-        "FastTrack Sandbox For vote should land",
-    );
-    assert_eq!(
-        fst_after_vote["status"], "Scheduled",
-        "FastTrack proposal should graduate Sandbox → Scheduled once the 1 bps threshold is met",
-    );
-    assert!(
-        !fst_after_vote["voting_start_time_ns"].is_null(),
-        "Graduating to Scheduled must seed voting_start_time_ns for the upcoming Voting window",
-    );
-
-    // Queue exercise: three active slots are now occupied (old classic + new classic +
-    // new FastTrack Sandbox), so a fourth approval must land in Queued under the default cap.
-    let queue_state: serde_json::Value = voting.view("get_queue_state").await?.json()?;
-    assert_eq!(
-        queue_state["active_proposals"].as_array().unwrap().len(),
-        3,
-        "Active slots should be full going into the queue test",
-    );
-    assert_eq!(
-        queue_state["pending_queue"].as_array().unwrap().len(),
-        0,
-        "Pending queue should be empty before we push a fourth proposal in",
-    );
-
-    let pid_queued = create_classic_proposal(&voting, &proposer).await?;
-    approve_classic(&voting, &reviewer, pid_queued).await?;
-    let queued: serde_json::Value = voting
-        .view("get_proposal")
-        .args_json(json!({ "proposal_id": pid_queued }))
-        .await?
-        .json()?;
-    assert_eq!(
-        queued["status"], "Queued",
-        "Fourth approved proposal must land Queued because the default max_active_proposals=3 is full",
-    );
-    assert!(
-        queued["snapshot_and_state"].is_null(),
-        "Queued proposals do not take a snapshot until they are promoted",
-    );
-
-    let queue_state: serde_json::Value = voting.view("get_queue_state").await?.json()?;
-    assert_eq!(
-        queue_state["pending_queue"],
-        json!([pid_queued]),
-        "pending_queue should now contain exactly the queued proposal",
-    );
-    assert_eq!(
-        queue_state["active_proposals"].as_array().unwrap().len(),
-        3,
-        "Active count should still be at the cap",
+    println!(
+        "Post-upgrade: {MISALIGNED_DELEGATOR} cleared and restored its delegations {:?}",
+        stuck.delegations
     );
 
     Ok(())

--- a/integration-tests/tests/test_contracts_upgrade.rs
+++ b/integration-tests/tests/test_contracts_upgrade.rs
@@ -40,9 +40,16 @@ async fn fetch_accounts(
     Ok(accounts)
 }
 
-/// Voting power under the deployed v1.1.0 formula.
+/// Voting power under the deployed v1.1.0 formula, which scaled the owner's balance by the
+/// aggregate delegated bps instead of subtracting each delegation's exact contribution.
 fn legacy_voting_power(account: &VenearAccount) -> NearToken {
-    let self_bps = Bps::new(10_000_u16.saturating_sub(account.delegated_bps()));
+    let delegated_bps: u32 = account
+        .delegations
+        .iter()
+        .map(|delegation| u32::from(delegation.bps))
+        .sum();
+    let delegated_bps = u16::try_from(delegated_bps).expect("delegated bps must fit into u16");
+    let self_bps = Bps::new(10_000_u16.saturating_sub(delegated_bps));
     let retained = near_add(
         self_bps * account.balance.near_balance,
         self_bps * account.balance.extra_venear_balance,

--- a/venear-contract/src/account.rs
+++ b/venear-contract/src/account.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use common::{Bps, VenearBalance, Version, events, near_add, truncate_to_seconds};
+use common::{VenearBalance, Version, events, truncate_to_seconds};
 use near_sdk::json_types::U64;
 
 /// Full information about the account
@@ -163,24 +163,14 @@ impl Contract {
         account
     }
 
-    /// Returns the "owned" voting power for an account — the portion that counts for ft_mint/ft_burn.
-    fn account_owned_total(account: &Account) -> NearToken {
-        let mut total = account.delegated_balance.total();
-        let self_bps = Bps::new(10_000_u16.saturating_sub(account.delegated_bps()));
-        if !self_bps.is_zero() {
-            total = near_add(total, account.balance.scale_by_bps(self_bps).total());
-        }
-        total
-    }
-
     pub fn internal_set_account(&mut self, account_id: AccountId, account: Account) {
         // Previous balance
         let old_balance = self
             .internal_get_account(&account_id)
-            .map(|old_account| Self::account_owned_total(&old_account))
+            .map(|old_account| old_account.owned_total())
             .unwrap_or_default();
         // New balance
-        let new_balance = Self::account_owned_total(&account);
+        let new_balance = account.owned_total();
         if new_balance > old_balance {
             events::emit::ft_mint(&account_id, new_balance.checked_sub(old_balance).unwrap());
         } else if new_balance < old_balance {

--- a/venear-contract/src/delegation.rs
+++ b/venear-contract/src/delegation.rs
@@ -105,8 +105,7 @@ impl Contract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{entry, fresh_contract, set_ctx};
-    use common::lockup_update::LockupUpdateV1;
+    use crate::test_utils::{apply_lockup_update, entry, fresh_contract, set_ctx};
     use common::{near_add, Bps};
 
     /// Register `caller` with 1 NEAR and each delegate with zero, so set_delegations can scale onto them.
@@ -280,32 +279,17 @@ mod tests {
         let year_ns: u64 = 365 * 86_400_000_000_000;
 
         // Year 3: the lockup reports newly locked NEAR; pools rebase onto the larger balance.
-        let locked = NearToken::from_near(111);
-        set_ctx(caller.clone(), 0, 3 * year_ns);
-        let account_internal = contract.internal_get_account_internal(&caller).unwrap();
-        contract.internal_lockup_update(
-            caller.clone(),
-            account_internal,
-            LockupUpdateV1 {
-                locked_near_balance: locked,
-                timestamp: (3 * year_ns).into(),
-                lockup_update_nonce: 1.into(),
-            },
+        apply_lockup_update(
+            &mut contract,
+            &caller,
+            NearToken::from_near(111),
+            3 * year_ns,
+            1,
         );
 
         // Year 7: the locked NEAR is withdrawn, forfeiting all extra veNEAR; each pool must
         // hold exactly the near-only share of the remaining deposit again.
-        set_ctx(caller.clone(), 0, 7 * year_ns);
-        let account_internal = contract.internal_get_account_internal(&caller).unwrap();
-        contract.internal_lockup_update(
-            caller.clone(),
-            account_internal,
-            LockupUpdateV1 {
-                locked_near_balance: NearToken::ZERO,
-                timestamp: (7 * year_ns).into(),
-                lockup_update_nonce: 2.into(),
-            },
-        );
+        apply_lockup_update(&mut contract, &caller, NearToken::ZERO, 7 * year_ns, 2);
         for delegation in &entries {
             assert_eq!(
                 delegated_total(&contract, delegation.account_id.as_str()),

--- a/venear-contract/src/delegation.rs
+++ b/venear-contract/src/delegation.rs
@@ -63,7 +63,7 @@ impl Contract {
             let mut delegate = self.internal_expect_account_updated(&delegation.account_id);
             delegate.delegated_balance = delegate
                 .delegated_balance
-                .pooled_sub_scaled(&owner.balance, delegation.bps);
+                .pooled_sub_delegation(&owner.balance, delegation.bps);
             self.internal_set_account(delegation.account_id.clone(), delegate);
         }
 
@@ -71,7 +71,7 @@ impl Contract {
             let mut delegate = self.internal_expect_account_updated(&entry.account_id);
             delegate.delegated_balance = delegate
                 .delegated_balance
-                .pooled_add_scaled(&owner.balance, entry.bps);
+                .pooled_add_delegation(&owner.balance, entry.bps);
             self.internal_set_account(entry.account_id.clone(), delegate);
         }
 
@@ -106,6 +106,8 @@ impl Contract {
 mod tests {
     use super::*;
     use crate::test_utils::{entry, fresh_contract, set_ctx};
+    use common::lockup_update::LockupUpdateV1;
+    use common::{near_add, Bps};
 
     /// Register `caller` with 1 NEAR and each delegate with zero, so set_delegations can scale onto them.
     fn registered_contract(caller: &AccountId, delegates: &[&str]) -> Contract {
@@ -116,6 +118,13 @@ mod tests {
             contract.internal_register_account(&id, NearToken::from_yoctonear(0));
         }
         contract
+    }
+
+    /// Expected pool contribution for an owner with zero extra veNEAR: the bps share of the near
+    /// balance, rounded down to whole milliNEAR.
+    fn contribution_near(balance: NearToken, bps: Bps) -> NearToken {
+        let share = balance.as_yoctonear() * u128::from(u16::from(bps)) / 10_000;
+        NearToken::from_millinear(share / NearToken::from_millinear(1).as_yoctonear())
     }
 
     fn delegated_total(contract: &Contract, account_id: &str) -> NearToken {
@@ -199,6 +208,132 @@ mod tests {
             delegated_total(&contract, "a.near"),
             NearToken::from_near(1)
         );
+    }
+
+    /// Regression test for mainnet tx HDtSFscvJQ7G6rA6Xy9XWdEnyLhaKJVPJbTDyyycChHX: a partial
+    /// delegation whose bps-scaled near share is not milliNEAR-aligned became un-clearable after
+    /// growth, underflowing `near_sub` in `pooled_sub_delegation`.
+    #[test]
+    fn clears_partial_delegation_after_growth_period() {
+        let caller: AccountId = "caller.near".parse().unwrap();
+        let delegate: AccountId = "a.near".parse().unwrap();
+        let mut contract = fresh_contract(caller.clone());
+        contract.internal_register_account(&caller, NearToken::from_millinear(4_100));
+        contract.internal_register_account(&delegate, NearToken::from_yoctonear(0));
+
+        set_ctx(caller.clone(), NearToken::from_near(1).as_yoctonear(), 0);
+        contract.set_delegations(vec![entry("a.near", 2_512)]);
+
+        let day_ns: u64 = 86_400_000_000_000;
+        set_ctx(
+            caller.clone(),
+            NearToken::from_near(1).as_yoctonear(),
+            27 * day_ns,
+        );
+        contract.set_delegations(vec![]);
+
+        assert_eq!(
+            contract
+                .get_account_info(caller)
+                .unwrap()
+                .account
+                .delegations,
+            vec![]
+        );
+        assert_eq!(
+            delegated_total(&contract, "a.near"),
+            NearToken::from_yoctonear(0)
+        );
+    }
+
+    /// Five delegates with different, milliNEAR-misaligned shares survive 10 years of growth,
+    /// a lockup deposit at year 3 and its withdrawal at year 7, and clear back to exactly zero.
+    #[test]
+    fn clears_five_delegates_after_ten_years() {
+        let caller: AccountId = "caller.near".parse().unwrap();
+        let delegates = ["a.near", "b.near", "c.near", "d.near", "e.near"];
+        // The 777-yocto tail keeps the balance itself off the milliNEAR grid (base != near).
+        let stake = near_add(NearToken::from_near(777), NearToken::from_yoctonear(777));
+        let mut contract = fresh_contract(caller.clone());
+        contract.internal_register_account(&caller, stake);
+        for delegate in delegates {
+            contract.internal_register_account(&delegate.parse().unwrap(), NearToken::ZERO);
+        }
+
+        let entries = vec![
+            entry("a.near", 2_512),
+            entry("b.near", 1_733),
+            entry("c.near", 999),
+            entry("d.near", 3_001),
+            entry("e.near", 777),
+        ];
+        set_ctx(caller.clone(), NearToken::from_near(1).as_yoctonear(), 0);
+        contract.set_delegations(entries.clone());
+
+        for delegation in &entries {
+            assert_eq!(
+                delegated_total(&contract, delegation.account_id.as_str()),
+                contribution_near(stake, delegation.bps)
+            );
+        }
+
+        let year_ns: u64 = 365 * 86_400_000_000_000;
+
+        // Year 3: the lockup reports newly locked NEAR; pools rebase onto the larger balance.
+        let locked = NearToken::from_near(111);
+        set_ctx(caller.clone(), 0, 3 * year_ns);
+        let account_internal = contract.internal_get_account_internal(&caller).unwrap();
+        contract.internal_lockup_update(
+            caller.clone(),
+            account_internal,
+            LockupUpdateV1 {
+                locked_near_balance: locked,
+                timestamp: (3 * year_ns).into(),
+                lockup_update_nonce: 1.into(),
+            },
+        );
+
+        // Year 7: the locked NEAR is withdrawn, forfeiting all extra veNEAR; each pool must
+        // hold exactly the near-only share of the remaining deposit again.
+        set_ctx(caller.clone(), 0, 7 * year_ns);
+        let account_internal = contract.internal_get_account_internal(&caller).unwrap();
+        contract.internal_lockup_update(
+            caller.clone(),
+            account_internal,
+            LockupUpdateV1 {
+                locked_near_balance: NearToken::ZERO,
+                timestamp: (7 * year_ns).into(),
+                lockup_update_nonce: 2.into(),
+            },
+        );
+        for delegation in &entries {
+            assert_eq!(
+                delegated_total(&contract, delegation.account_id.as_str()),
+                contribution_near(stake, delegation.bps)
+            );
+        }
+
+        set_ctx(
+            caller.clone(),
+            NearToken::from_near(1).as_yoctonear(),
+            10 * year_ns,
+        );
+        contract.set_delegations(vec![]);
+
+        assert_eq!(
+            contract
+                .get_account_info(caller)
+                .unwrap()
+                .account
+                .delegations,
+            vec![]
+        );
+        for delegate in delegates {
+            assert_eq!(
+                delegated_total(&contract, delegate),
+                NearToken::from_yoctonear(0)
+            );
+        }
     }
 
     #[test]

--- a/venear-contract/src/delegation.rs
+++ b/venear-contract/src/delegation.rs
@@ -106,7 +106,7 @@ impl Contract {
 mod tests {
     use super::*;
     use crate::test_utils::{apply_lockup_update, entry, fresh_contract, set_ctx};
-    use common::{near_add, Bps};
+    use common::{Bps, near_add};
 
     /// Register `caller` with 1 NEAR and each delegate with zero, so set_delegations can scale onto them.
     fn registered_contract(caller: &AccountId, delegates: &[&str]) -> Contract {

--- a/venear-contract/src/lockup.rs
+++ b/venear-contract/src/lockup.rs
@@ -3,11 +3,11 @@ use crate::config::LockupContractConfig;
 use crate::*;
 use common::events;
 use common::lockup_update::{LockupUpdateV1, VLockupUpdate};
-use common::near_add;
+use common::{near_add, near_sub};
 use near_sdk::json_types::U64;
 use near_sdk::{Gas, IntoStorageKey, Promise, env, is_promise_success};
 #[cfg(target_arch = "wasm32")]
-use {common::near_sub, near_sdk::json_types::Base58CryptoHash};
+use near_sdk::json_types::Base58CryptoHash;
 
 const LOCKUP_DEPLOY_MIN_GAS: Gas = Gas::from_tgas(20);
 const ON_LOCKUP_DEPLOYED: Gas = Gas::from_tgas(15);
@@ -157,8 +157,10 @@ impl Contract {
         let mut account: Account = self.internal_expect_account_updated(&account_id);
         let old_balance = account.balance;
         let mut global_state: GlobalState = self.internal_global_state_updated();
-        // Decreasing the locked NEAR will result in dropped extra veNEAR rewards.
-        if lockup_update.locked_near_balance < old_balance.near_balance {
+        // Decreasing the locked NEAR will result in dropped extra veNEAR rewards. The stored
+        // near balance includes the storage deposit, so strip it to compare locked to locked.
+        let old_locked_near_balance = near_sub(old_balance.near_balance, account_internal.deposit);
+        if lockup_update.locked_near_balance < old_locked_near_balance {
             account.balance.extra_venear_balance = NearToken::ZERO;
         }
         // Updating balance and also adding internal balance deposit.
@@ -378,4 +380,62 @@ fn internal_get_hash_and_size(register_id: u64) -> (u64, CryptoHash) {
     }
     let hash = env::read_register(hash_register).unwrap();
     (size, hash.try_into().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{apply_lockup_update, fresh_contract};
+
+    const DAY_NS: u64 = 86_400_000_000_000;
+
+    /// Regression test: the forfeit check must compare locked to locked, excluding the storage
+    /// deposit. Locking a small extra amount (less than the deposit) must keep accrued extra.
+    #[test]
+    fn small_lock_increase_keeps_extra_venear() {
+        let caller: AccountId = "caller.near".parse().unwrap();
+        let mut contract = fresh_contract(caller.clone());
+        contract.internal_register_account(&caller, NearToken::from_near(1));
+
+        apply_lockup_update(&mut contract, &caller, NearToken::from_near(100), 0, 1);
+        apply_lockup_update(
+            &mut contract,
+            &caller,
+            NearToken::from_millinear(100_500),
+            30 * DAY_NS,
+            2,
+        );
+
+        let balance = contract.get_account_info(caller).unwrap().account.balance;
+        assert_eq!(balance.near_balance, NearToken::from_millinear(101_500));
+        assert_eq!(
+            balance.extra_venear_balance,
+            contract.internal_get_venear_growth_config().calculate(
+                0.into(),
+                (30 * DAY_NS).into(),
+                NearToken::from_near(101)
+            )
+        );
+    }
+
+    /// Decreasing the locked NEAR still forfeits all accrued extra veNEAR.
+    #[test]
+    fn unlock_forfeits_extra_venear() {
+        let caller: AccountId = "caller.near".parse().unwrap();
+        let mut contract = fresh_contract(caller.clone());
+        contract.internal_register_account(&caller, NearToken::from_near(1));
+
+        apply_lockup_update(&mut contract, &caller, NearToken::from_near(100), 0, 1);
+        apply_lockup_update(
+            &mut contract,
+            &caller,
+            NearToken::from_millinear(99_999),
+            30 * DAY_NS,
+            2,
+        );
+
+        let balance = contract.get_account_info(caller).unwrap().account.balance;
+        assert_eq!(balance.near_balance, NearToken::from_millinear(100_999));
+        assert_eq!(balance.extra_venear_balance, NearToken::from_yoctonear(0));
+    }
 }

--- a/venear-contract/src/lockup.rs
+++ b/venear-contract/src/lockup.rs
@@ -174,8 +174,8 @@ impl Contract {
                 self.internal_expect_account_updated(&delegation.account_id);
             delegation_account.delegated_balance = delegation_account
                 .delegated_balance
-                .pooled_sub_scaled(&old_balance, delegation.bps)
-                .pooled_add_scaled(&account.balance, delegation.bps);
+                .pooled_sub_delegation(&old_balance, delegation.bps)
+                .pooled_add_delegation(&account.balance, delegation.bps);
             self.internal_set_account(delegation.account_id.clone(), delegation_account);
         }
         self.internal_set_account_internal(account_id.clone(), account_internal);

--- a/venear-contract/src/lockup.rs
+++ b/venear-contract/src/lockup.rs
@@ -4,10 +4,10 @@ use crate::*;
 use common::events;
 use common::lockup_update::{LockupUpdateV1, VLockupUpdate};
 use common::{near_add, near_sub};
-use near_sdk::json_types::U64;
-use near_sdk::{Gas, IntoStorageKey, Promise, env, is_promise_success};
 #[cfg(target_arch = "wasm32")]
 use near_sdk::json_types::Base58CryptoHash;
+use near_sdk::json_types::U64;
+use near_sdk::{Gas, IntoStorageKey, Promise, env, is_promise_success};
 
 const LOCKUP_DEPLOY_MIN_GAS: Gas = Gas::from_tgas(20);
 const ON_LOCKUP_DEPLOYED: Gas = Gas::from_tgas(15);
@@ -401,7 +401,7 @@ mod tests {
         apply_lockup_update(
             &mut contract,
             &caller,
-            NearToken::from_millinear(100_500),
+            NearToken::from_millinear(100_500), // 100.5 NEAR
             30 * DAY_NS,
             2,
         );

--- a/venear-contract/src/test_utils.rs
+++ b/venear-contract/src/test_utils.rs
@@ -5,6 +5,7 @@ use crate::Contract;
 use crate::config::Config;
 use common::Bps;
 use common::account::DelegationEntry;
+use common::lockup_update::LockupUpdateV1;
 use common::test_utils::{acc, fixed_rate_growth_config};
 pub use common::test_utils::{owner, set_ctx};
 use near_sdk::json_types::U64;
@@ -15,6 +16,27 @@ pub fn entry(account_id: &str, bps: u16) -> DelegationEntry {
         account_id: acc(account_id),
         bps: Bps::new(bps),
     }
+}
+
+/// Applies a lockup update for `caller` at `timestamp_ns` reporting `locked` NEAR.
+pub fn apply_lockup_update(
+    contract: &mut Contract,
+    caller: &AccountId,
+    locked: NearToken,
+    timestamp_ns: u64,
+    nonce: u64,
+) {
+    set_ctx(caller.clone(), 0, timestamp_ns);
+    let account_internal = contract.internal_get_account_internal(caller).unwrap();
+    contract.internal_lockup_update(
+        caller.clone(),
+        account_internal,
+        LockupUpdateV1 {
+            locked_near_balance: locked,
+            timestamp: timestamp_ns.into(),
+            lockup_update_nonce: nonce.into(),
+        },
+    );
 }
 
 pub fn fresh_contract(predecessor: AccountId) -> Contract {

--- a/venear-contract/src/upgrade.rs
+++ b/venear-contract/src/upgrade.rs
@@ -1,75 +1,51 @@
-use crate::config::LockupContractConfig;
 use crate::*;
+use common::PooledVenearBalance;
 #[cfg(target_arch = "wasm32")]
 use near_sdk::Gas;
-use near_sdk::borsh::{self, BorshDeserialize};
-use near_sdk::json_types::U64;
+use std::collections::BTreeMap;
 
 #[cfg(target_arch = "wasm32")]
 const MIGRATE_STATE_GAS: Gas = Gas::from_tgas(50);
 #[cfg(target_arch = "wasm32")]
 const GET_CONFIG_GAS: Gas = Gas::from_tgas(5);
 
-/// Default applied during migration of contracts deployed before `max_delegations`
-/// was made configurable. Matches the previous hardcoded constant.
-const DEFAULT_MAX_DELEGATIONS: u32 = 8;
-
-/// Pre-migration `Config` layout (no `max_delegations` field).
-#[derive(BorshDeserialize)]
-#[borsh(crate = "borsh")]
-struct OldConfig {
-    lockup_contract_config: Option<LockupContractConfig>,
-    unlock_duration_ns: U64,
-    staking_pool_whitelist_account_id: AccountId,
-    lockup_code_deployers: Vec<AccountId>,
-    local_deposit: NearToken,
-    min_lockup_deposit: NearToken,
-    owner_account_id: AccountId,
-    guardians: Vec<AccountId>,
-    proposed_new_owner_account_id: Option<AccountId>,
-}
-
-/// Pre-migration top-level contract layout. Mirrors `Contract` but with `OldConfig`.
-#[derive(BorshDeserialize)]
-#[borsh(crate = "borsh")]
-struct OldContract {
-    tree: MerkleTree<VAccount, VGlobalState>,
-    accounts: LookupMap<AccountId, VAccountInternal>,
-    config: OldConfig,
-    paused: bool,
-}
-
 #[near]
 impl Contract {
     /// Private method to migrate the contract state during the contract upgrade.
-    /// Backfills the new `max_delegations` config field with the legacy default
-    /// when the stored state still uses the pre-`max_delegations` layout.
     #[private]
     #[init(ignore_state)]
     pub fn migrate_state() -> Self {
-        let raw = env::storage_read(b"STATE").expect("Missing contract state");
-        if let Ok(current) = Self::try_from_slice(&raw) {
-            return current;
+        let mut contract: Contract = env::state_read().unwrap();
+        let timestamp = env::block_timestamp().into();
+        // Delegates with a non-zero stored balance start at zero so orphaned balances get cleared.
+        let mut recomputed: BTreeMap<AccountId, PooledVenearBalance> = BTreeMap::new();
+        for index in 0..contract.tree.len() {
+            let mut account: Account = contract.tree.get_by_index(index).unwrap().clone().into();
+            if account.delegated_balance != PooledVenearBalance::default() {
+                recomputed.entry(account.account_id.clone()).or_default();
+            }
+            if account.delegations.is_empty() {
+                continue;
+            }
+            account.update(timestamp, contract.internal_get_venear_growth_config());
+            for delegation in &account.delegations {
+                let delegated_balance = recomputed
+                    .get(&delegation.account_id)
+                    .copied()
+                    .unwrap_or_default()
+                    .pooled_add_delegation(&account.balance, delegation.bps);
+                recomputed.insert(delegation.account_id.clone(), delegated_balance);
+            }
         }
-        let old = OldContract::try_from_slice(&raw)
-            .unwrap_or_else(|_| env::panic_str("Cannot deserialize the contract state."));
-        Self {
-            tree: old.tree,
-            accounts: old.accounts,
-            config: Config {
-                lockup_contract_config: old.config.lockup_contract_config,
-                unlock_duration_ns: old.config.unlock_duration_ns,
-                staking_pool_whitelist_account_id: old.config.staking_pool_whitelist_account_id,
-                lockup_code_deployers: old.config.lockup_code_deployers,
-                local_deposit: old.config.local_deposit,
-                min_lockup_deposit: old.config.min_lockup_deposit,
-                owner_account_id: old.config.owner_account_id,
-                guardians: old.config.guardians,
-                proposed_new_owner_account_id: old.config.proposed_new_owner_account_id,
-                max_delegations: DEFAULT_MAX_DELEGATIONS,
-            },
-            paused: old.paused,
+        for (account_id, delegated_balance) in recomputed {
+            let mut delegate = contract.internal_expect_account_updated(&account_id);
+            if delegate.delegated_balance == delegated_balance {
+                continue;
+            }
+            delegate.delegated_balance = delegated_balance;
+            contract.internal_set_account(account_id, delegate);
         }
+        contract
     }
 
     /// Returns the version of the contract from the Cargo.toml.

--- a/voting-contract/src/upgrade.rs
+++ b/voting-contract/src/upgrade.rs
@@ -1,10 +1,4 @@
-use crate::config::Config;
-use crate::proposal::{Proposal, VProposal, is_active_status};
 use crate::*;
-use common::Bps;
-use near_sdk::borsh::{self, BorshDeserialize};
-use near_sdk::json_types::U64;
-use near_sdk::store::{IterableSet, LookupMap, Vector};
 #[cfg(target_arch = "wasm32")]
 use near_sdk::{Gas, sys};
 
@@ -13,105 +7,14 @@ const MIGRATE_STATE_GAS: Gas = Gas::from_tgas(50);
 #[cfg(target_arch = "wasm32")]
 const GET_CONFIG_GAS: Gas = Gas::from_tgas(5);
 
-// Defaults applied when migrating a contract that predates the merged flow.
-const DEFAULT_BOND_AMOUNT_NEAR: u128 = 100;
-// TODO: change the migration default treasury once the real treasury account is set up.
-const DEFAULT_TREASURY_ACCOUNT_ID: &str = "hos-deposits.sputnik-dao.near";
-const DEFAULT_SIMPLE_MAJORITY_BPS: Bps = Bps::new(5_000);
-const DEFAULT_STRONG_MAJORITY_BPS: Bps = Bps::new(6_667);
-const DEFAULT_SANDBOX_DURATION_NS: u64 = 7 * 24 * 60 * 60 * 1_000_000_000; // 7 days
-const DEFAULT_SANDBOX_THRESHOLD_BPS: Bps = Bps::new(3_000);
-const DEFAULT_MAX_ACTIVE_PROPOSALS: u32 = 3;
-const DEFAULT_FAST_TRACK_PROPOSAL_EXPIRATION_NS: u64 = 2 * 24 * 60 * 60 * 1_000_000_000; // 2 days
-const DEFAULT_FAST_TRACK_VOTING_DURATION_NS: u64 = 5 * 24 * 60 * 60 * 1_000_000_000; // 5 days
-
-/// Config from v1.0.3 (pre-merge). No FastTrack fields.
-#[derive(Clone, BorshDeserialize, near_sdk::borsh::BorshSerialize)]
-#[borsh(crate = "borsh")]
-struct OldConfig {
-    venear_account_id: AccountId,
-    reviewer_ids: Vec<AccountId>,
-    council_ids: Vec<AccountId>,
-    owner_account_id: AccountId,
-    voting_duration_ns: U64,
-    timelock_duration_ns: U64,
-    base_proposal_fee: NearToken,
-    vote_storage_fee: NearToken,
-    guardians: Vec<AccountId>,
-    proposal_expiration_ns: U64,
-    proposed_new_owner_account_id: Option<AccountId>,
-    quorum_threshold_bps: u16,
-    quorum_floor: NearToken,
-    approval_threshold_bps: u16,
-}
-
-/// Contract state from v1.0.3.
-#[derive(BorshDeserialize)]
-#[borsh(crate = "borsh")]
-struct OldContract {
-    config: OldConfig,
-    proposals: Vector<VProposal>,
-    proposal_metadata: Vector<VProposalMetadata>,
-    votes: LookupMap<(AccountId, ProposalId), u8>,
-    approved_proposals: Vector<ProposalId>,
-    paused: bool,
-}
-
 #[near]
 impl Contract {
-    /// Private method to migrate the contract state from v1.0.3 (pre-merge) to the merged flow.
-    /// Rewrites every legacy proposal into the unified `Proposal` shape with `flow = Classic`.
+    /// Private method to migrate the contract state during the contract upgrade.
+    /// The stored layout is unchanged since v1.1.0, so the state is read as-is.
     #[private]
     #[init(ignore_state)]
     pub fn migrate_state() -> Self {
-        let mut old: OldContract = env::state_read().unwrap();
-
-        let mut proposals = Vector::new(StorageKeys::Proposal);
-        let mut active_proposals = IterableSet::new(StorageKeys::ActiveProposals);
-        for (idx, legacy) in old.proposals.iter().enumerate() {
-            let proposal: Proposal = legacy.clone().into();
-            if is_active_status(proposal.status) {
-                active_proposals.insert(ProposalId::try_from(idx).unwrap());
-            }
-            proposals.push(VProposal::Current(proposal));
-        }
-
-        // The merged flow no longer tracks `approved_proposals` separately; release its storage.
-        old.approved_proposals.clear();
-
-        Self {
-            config: Config {
-                venear_account_id: old.config.venear_account_id,
-                reviewer_ids: old.config.reviewer_ids,
-                council_ids: old.config.council_ids,
-                owner_account_id: old.config.owner_account_id,
-                classic_voting_duration_ns: old.config.voting_duration_ns,
-                fast_track_voting_duration_ns: U64(DEFAULT_FAST_TRACK_VOTING_DURATION_NS),
-                timelock_duration_ns: old.config.timelock_duration_ns,
-                base_proposal_fee: old.config.base_proposal_fee,
-                bond_amount: NearToken::from_near(DEFAULT_BOND_AMOUNT_NEAR),
-                treasury_account_id: DEFAULT_TREASURY_ACCOUNT_ID.parse().unwrap(),
-                vote_storage_fee: old.config.vote_storage_fee,
-                guardians: old.config.guardians,
-                classic_proposal_expiration_ns: old.config.proposal_expiration_ns,
-                fast_track_proposal_expiration_ns: U64(DEFAULT_FAST_TRACK_PROPOSAL_EXPIRATION_NS),
-                proposed_new_owner_account_id: old.config.proposed_new_owner_account_id,
-                quorum_threshold_bps: Bps::new(old.config.quorum_threshold_bps),
-                quorum_floor: old.config.quorum_floor,
-                approval_threshold_bps: Bps::new(old.config.approval_threshold_bps),
-                simple_majority_threshold_bps: DEFAULT_SIMPLE_MAJORITY_BPS,
-                strong_majority_threshold_bps: DEFAULT_STRONG_MAJORITY_BPS,
-                sandbox_duration_ns: U64(DEFAULT_SANDBOX_DURATION_NS),
-                sandbox_threshold_bps: DEFAULT_SANDBOX_THRESHOLD_BPS,
-                max_active_proposals: DEFAULT_MAX_ACTIVE_PROPOSALS,
-            },
-            proposals,
-            proposal_metadata: old.proposal_metadata,
-            votes: old.votes,
-            paused: old.paused,
-            pending_queue: Vector::new(StorageKeys::PendingQueue),
-            active_proposals,
-        }
+        env::state_read().unwrap()
     }
 
     /// Returns the version of the contract from the Cargo.toml.


### PR DESCRIPTION
**Rounding error in partial delegation**

Delegated balances were computed with scale_by_bps (bps × balance), which produces a near_balance that isn't milliNEAR-aligned. The pooled delegate balance truncates to milliNEAR, so the credit added to a pool and the debit subtracted from it later didn't match — and once extra veNEAR growth was applied on top of that mismatched base, the drift compounded until the delegation could no longer be cleared (near_sub underflow in the pooled subtract).

- VenearBalance::scale_by_bps → delegation_contribution(bps): truncate the delegated NEAR to whole milliNEAR first, then scale extra_venear_balance by the realized ratio rather than by bps. Add/sub of a delegation is now exactly reversible, including after arbitrary growth.
- pooled_add_scaled / pooled_sub_scaled → pooled_add_delegation / pooled_sub_delegation; the sub-milliNEAR remainder stays with the owner.
- Account::total_balance now goes through update + the new owned_total, so the query path and the stored path compute voting power the same way.

**Small lockup increases forfeited all accrued extra veNEAR**

on_lockup_update decides whether the user unlocked NEAR by comparing the newly reported locked_near_balance against the account's stored balance.near_balance. But the stored balance includes the account's storage deposit, so it's always larger than what the lockup reports. Any lock increase smaller than the deposit still looked like a decrease, tripping the "unlocking forfeits extra veNEAR" branch and zeroing the user's accrued growth. The check now strips account_internal.deposit and compares locked-to-locked; genuine decreases still forfeit as intended.

**Migration**

venear-contract::migrate_state recomputes every delegate's pooled balance from scratch by walking the Merkle tree, zeroing delegates whose stored balance is orphaned. The stale pre-max_delegations and pre-FastTrack migration paths are removed (the voting contract isn't upgraded in this release).

**Tests**

Unit regressions for the mainnet tx and for both lockup branches; 
test_contracts_upgrade.rs now runs the migration against imported mainnet state via the new setup/mainnet.rs helper.