### PR TITLE
ci: enable workflows for existing contracts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_NEAR_TAG: cargo-near-v0.22.0
 
 jobs:
   build:
@@ -26,7 +27,7 @@ jobs:
       # fail with PrepareError(Deserialization) on near-workspaces sandbox.
       - name: Install cargo-near
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf "https://github.com/near/cargo-near/releases/download/${CARGO_NEAR_TAG}/cargo-near-installer.sh" | sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           cargo near --version
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build WASM
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.86.0
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Build the same cargo-near artifacts used by deploy/test tooling. Plain
+      # `cargo build --target wasm32-unknown-unknown` can produce modules that
+      # fail with PrepareError(Deserialization) on near-workspaces sandbox.
+      - name: Install cargo-near
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          cargo near --version
+
+      - name: Build contract wasm
+        run: make all-contracts

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,26 @@
+name: Clippy
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.86.0
+        with:
+          components: clippy
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets --all-features --exclude integration-tests

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Format
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.86.0
+        with:
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.86.0
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      # `make test` builds cargo-near WASM artifacts before running tests. Plain
+      # `cargo build --target wasm32-unknown-unknown` can produce modules that
+      # fail with PrepareError(Deserialization) on near-workspaces sandbox.
+      - name: Install cargo-near
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          cargo near --version
+
+      - name: Run all tests
+        run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_NEAR_TAG: cargo-near-v0.22.0
 
 jobs:
   test:
@@ -26,7 +27,7 @@ jobs:
       # fail with PrepareError(Deserialization) on near-workspaces sandbox.
       - name: Install cargo-near
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf "https://github.com/near/cargo-near/releases/download/${CARGO_NEAR_TAG}/cargo-near-installer.sh" | sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           cargo near --version
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 RES_LOCAL := $(ROOT)res/local
-INTEGRATION_TEST_FILES := $(sort $(filter-out test_lockup.rs,$(notdir $(wildcard $(ROOT)integration-tests/tests/test_*.rs))))
+INTEGRATION_TEST_FILES := $(sort $(notdir $(wildcard $(ROOT)integration-tests/tests/test_*.rs)))
 INTEGRATION_TEST_ARGS := $(foreach test,$(patsubst %.rs,%,$(INTEGRATION_TEST_FILES)),--test $(test))
 
 help:
@@ -26,8 +26,8 @@ help:
 	@echo "  make check-<name>   e.g. make check-voting-contract, make check-whitelist"
 	@echo ""
 	@echo "Tests:"
-	@echo "  make test                                 run workspace tests and integration tests except test_lockup"
-	@echo "  make test-integration                     run integration tests except test_lockup"
+	@echo "  make test                                 run workspace tests and integration tests"
+	@echo "  make test-integration                     run integration tests"
 
 sandbox-staking-whitelist-contract:
 	cd "$(ROOT)sandbox-staking-whitelist-contract" && cargo near build non-reproducible-wasm

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,76 @@
+# House of Stake per-contract NEAR WASM builds.
+
+.DEFAULT_GOAL := help
+
+.PHONY: help all-contracts \
+	sandbox-staking-whitelist-contract venear-contract lockup-contract voting-contract \
+	whitelist venear lockup voting \
+	check-sandbox-staking-whitelist-contract check-venear-contract check-lockup-contract \
+	check-voting-contract check-whitelist check-venear check-lockup check-voting \
+	test test-integration
+
+ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+RES_LOCAL := $(ROOT)res/local
+INTEGRATION_TEST_ARGS := $(shell find "$(ROOT)integration-tests/tests" -maxdepth 1 -name 'test_*.rs' ! -name 'test_lockup.rs' -printf '--test %f\n' | sed 's/\.rs$$//' | sort)
+
+help:
+	@echo "WASM builds (cargo near build non-reproducible-wasm; copies .wasm to res/local/):"
+	@echo "  make sandbox-staking-whitelist-contract   (alias: make whitelist)"
+	@echo "  make venear-contract                      (alias: make venear)"
+	@echo "  make lockup-contract                      (alias: make lockup)"
+	@echo "  make voting-contract                      (alias: make voting; sandbox feature for integration tests)"
+	@echo "  make all-contracts                        all of the above, in order"
+	@echo ""
+	@echo "Fast compile checks:"
+	@echo "  make check-<name>   e.g. make check-voting-contract, make check-whitelist"
+	@echo ""
+	@echo "Tests:"
+	@echo "  make test                                 run workspace tests and integration tests except test_lockup"
+	@echo "  make test-integration                     run integration tests except test_lockup"
+
+sandbox-staking-whitelist-contract:
+	cd "$(ROOT)sandbox-staking-whitelist-contract" && cargo near build non-reproducible-wasm
+	mkdir -p "$(RES_LOCAL)"
+	cp "$(ROOT)target/near/sandbox_staking_whitelist_contract/sandbox_staking_whitelist_contract.wasm" "$(RES_LOCAL)/"
+
+venear-contract:
+	cd "$(ROOT)venear-contract" && cargo near build non-reproducible-wasm
+	mkdir -p "$(RES_LOCAL)"
+	cp "$(ROOT)target/near/venear_contract/venear_contract.wasm" "$(RES_LOCAL)/"
+
+lockup-contract:
+	cd "$(ROOT)lockup-contract" && cargo near build non-reproducible-wasm
+	mkdir -p "$(RES_LOCAL)"
+	cp "$(ROOT)target/near/lockup_contract/lockup_contract.wasm" "$(RES_LOCAL)/"
+
+voting-contract:
+	cd "$(ROOT)voting-contract" && cargo near build non-reproducible-wasm --features sandbox
+	mkdir -p "$(RES_LOCAL)"
+	cp "$(ROOT)target/near/voting_contract/voting_contract.wasm" "$(RES_LOCAL)/"
+
+all-contracts: sandbox-staking-whitelist-contract venear-contract lockup-contract voting-contract
+
+whitelist: sandbox-staking-whitelist-contract
+venear: venear-contract
+lockup: lockup-contract
+voting: voting-contract
+
+check-sandbox-staking-whitelist-contract check-whitelist:
+	cd "$(ROOT)" && cargo check -p sandbox-staking-whitelist-contract
+
+check-venear-contract check-venear:
+	cd "$(ROOT)" && cargo check -p venear-contract
+
+check-lockup-contract check-lockup:
+	cd "$(ROOT)" && cargo check -p lockup-contract
+
+check-voting-contract check-voting:
+	cd "$(ROOT)" && cargo check -p voting-contract
+
+test:
+	$(MAKE) all-contracts
+	cd "$(ROOT)" && cargo test --workspace --exclude integration-tests
+	$(MAKE) test-integration
+
+test-integration:
+	cd "$(ROOT)" && cargo test -p integration-tests $(INTEGRATION_TEST_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 RES_LOCAL := $(ROOT)res/local
-INTEGRATION_TEST_ARGS := $(shell find "$(ROOT)integration-tests/tests" -maxdepth 1 -name 'test_*.rs' ! -name 'test_lockup.rs' -printf '--test %f\n' | sed 's/\.rs$$//' | sort)
+INTEGRATION_TEST_FILES := $(sort $(filter-out test_lockup.rs,$(notdir $(wildcard $(ROOT)integration-tests/tests/test_*.rs))))
+INTEGRATION_TEST_ARGS := $(foreach test,$(patsubst %.rs,%,$(INTEGRATION_TEST_FILES)),--test $(test))
 
 help:
 	@echo "WASM builds (cargo near build non-reproducible-wasm; copies .wasm to res/local/):"
@@ -73,4 +74,5 @@ test:
 	$(MAKE) test-integration
 
 test-integration:
+	@if [ -z "$(strip $(INTEGRATION_TEST_ARGS))" ]; then echo "No integration tests matched"; exit 1; fi
 	cd "$(ROOT)" && cargo test -p integration-tests $(INTEGRATION_TEST_ARGS)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,3 +4,4 @@
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
 channel = "1.86"
 components = ["rustfmt", "clippy", "rust-analyzer"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary
- Add GitHub Actions for build, clippy, rustfmt, and tests on `main` / `master`.
- Add a pre-staking `Makefile` for existing contracts only: sandbox staking whitelist, veNEAR, lockup, and voting.
- Build deployable WASM artifacts with `cargo near build non-reproducible-wasm` instead of plain wasm32 cargo builds.
- Pin CI to cargo-near `0.22.0` via the `cargo-near-v0.22.0` release tag.
- Declare `wasm32-unknown-unknown` in `rust-toolchain.toml` so cargo-near sees the target in CI.
- Run all integration tests through the Makefile, using Make-native test discovery instead of a non-portable `find` pipeline.

## Scope
This intentionally does not reference `staking-contract` or `mock-staking-pool-contract`, so it can merge to `main` before those contracts are introduced.

## Validation
- `curl -I -L https://github.com/near/cargo-near/releases/download/cargo-near-v0.22.0/cargo-near-installer.sh`
- `make -n test-integration`
- `make -n test`
- `rustup show active-toolchain && rustup target list --installed | rg 'wasm32-unknown-unknown|x86_64'`
- `make -n all-contracts`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --exclude integration-tests`
- `make all-contracts`
- `cargo test --workspace --exclude integration-tests`
- `cargo test -p integration-tests --test test_contracts_upgrade --test test_venear --test test_voting --test test_voting_fst --test test_voting_partial_delegation --test test_voting_queue --no-run`

Note: `test_lockup` is now enabled in CI so we can observe whether it is reliable enough to keep.
