### PR TITLE
Integrate stake v1 updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build WASM
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, feat/stake-v1]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, feat/stake-v1]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,9 +2,9 @@ name: Clippy
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, feat/stake-v1]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, feat/stake-v1]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,9 +2,9 @@ name: Format
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, feat/stake-v1]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, feat/stake-v1]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, feat/stake-v1]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, feat/stake-v1]
 
 env:
   CARGO_TERM_COLOR: always

--- a/staking-contract/docs/API.md
+++ b/staking-contract/docs/API.md
@@ -27,6 +27,8 @@ Reference for **on-chain methods** exposed by `staking-contract` (Rust type name
 | `get_version` | — | `string` | Crate package version string. |
 | `is_paused` | — | `bool` | Global pause flag. |
 | `get_account` | `account_id: AccountId` | `Account \| null` | NEP-style prepaid **`storage_deposit`** only. |
+| `get_accounts` | `from_index: u64`, `limit: u64` | `AccountView[]` | Paginated registered accounts from the enumerable account index, including each row's account id. |
+| `get_account_ids` | `from_index: u64`, `limit: u64` | `AccountId[]` | Paginated registered account ids from the enumerable account index. |
 | `storage_balance_bounds` | — | `StorageBalanceBounds` | NEP-145 minimum registration balance; `max` is `null` because storage top-ups are unbounded. |
 | `storage_balance_of` | `account_id: AccountId` | `StorageBalance \| null` | NEP-145 storage balance; returns `null` for unregistered accounts. |
 | `get_validator` | `validator_id: AccountId` | `Validator \| null` | Validator row for one staking pool contract account. |
@@ -39,7 +41,9 @@ Reference for **on-chain methods** exposed by `staking-contract` (Rust type name
 | `get_subscription` | `subscription_id: string` | `Subscription \| null` | Subscription (`sub_*`). |
 | `get_subscription_for_product` | `account_id`, `product_id` | `Subscription \| null` | Lookup by `(account, product)`. |
 | `get_subscription_for_price` | `account_id`, `price_id` | `Subscription \| null` | Resolves product from price, then same as above. |
+| `get_subscriptions` | `from_index: u64`, `limit: u64` | `Subscription[]` | Paginated subscriptions, with due pending updates projected in the returned views. |
 | `get_subscriptions_for_account` | `account_id`, `from_index: u64`, `limit: u64` | `Subscription[]` | Paginated subscriptions owned by an account, with due pending updates projected in the returned views. |
+| `get_subscriptions_for_product` | `product_id`, `from_index: u64`, `limit: u64` | `Subscription[]` | Paginated subscriptions currently indexed under a product, with due pending updates projected in the returned views. |
 | `get_purchase` | `purchase_id: string` | `Purchase \| null` | Direct payment purchase record (`pay_*`). |
 | `get_purchases` | `from_index: u64`, `limit: u64` | `Purchase[]` | Paginated direct payment purchases. |
 | `get_purchases_for_account` | `account_id`, `from_index: u64`, `limit: u64` | `Purchase[]` | Paginated direct payment purchases by buyer account. |
@@ -59,6 +63,8 @@ Reference for **on-chain methods** exposed by `staking-contract` (Rust type name
 | `storage_deposit` | Any | **Attach NEAR** | NEP-145 register/top-up: `account_id?: AccountId`, `registration_only?: bool`. With `registration_only=true`, only the amount needed to reach `min_storage_deposit` is retained and excess is refunded. Non-registration top-ups must satisfy retained storage for `min_storage_deposit + per_lock_storage_stake × user_lock_count + per_farm_position_storage_stake × user_farm_position_count + per_purchase_storage_stake × user_purchase_count`. |
 | `storage_withdraw` | Account owner | **1 yocto** + optional `amount: NearToken` | NEP-145 withdraw from `available`; omitting `amount` withdraws all available storage. |
 | `storage_unregister` | Account owner | **1 yocto** + optional `force: bool` | NEP-145 unregister/refund when the account has no retained per-lock, per-purchase, subscription, farm-position, or pending-unstake storage. `force=true` is rejected; without force the method returns `false` instead of deleting accounts that still own retained records. |
+| `get_accounts` | Anyone | 0 | `from_index`, `limit`. Lists registered account rows from the enumerable account index with `account_id` and storage fields. During upgrade, discoverable accounts from purchases, subscriptions, and legacy pending-unstake account references are backfilled; storage-only pre-upgrade accounts remain readable by `get_account` and appear in `get_accounts` after their next storage mutation. |
+| `get_account_ids` | Anyone | 0 | `from_index`, `limit`. Lists registered account ids from the enumerable account index. During upgrade, discoverable accounts from purchases, subscriptions, and legacy pending-unstake account references are backfilled; storage-only pre-upgrade accounts remain readable and appear after their next storage mutation. |
 
 ---
 
@@ -138,6 +144,9 @@ Lifecycle RPCs (locking / renewal stays in **`lock`** above).
 | `cancel_subscription` | Subscriber | **1 yocto** | — | **`subscription_id`** — set **`cancel_at_period_end`**; lock remains until **`lock.end_ns`**, then **`unlock`**. After **`end_ns`**, next **`lock`** starts a new period. |
 | `resume_subscription` | Subscriber | **1 yocto** | — | **`subscription_id`** — clear **`cancel_at_period_end`** while **`Active`**, only before stored **`end_ns`** (current billing period). Fails after period end; use **`lock`** for a new period. Requires **`cancel_at_period_end == true`**. |
 | `update_subscription` | Subscriber | **Attach delta NEAR for increases; 1 yocto otherwise** | **`PromiseOrValue<SubscriptionPlanChangeOutcome>`** | **`subscription_id`, `target_price_id`, `target_amount`** — unified plan update. Stake increases apply immediately after the same pre-user pipeline as **`lock`**; stake decreases are scheduled for the billing boundary, projected in views after `apply_ns`, and lazily committed by later mutations after validator settlement; price-only changes with unchanged stake apply immediately. |
+| `get_subscriptions` | Anyone | 0 | `from_index`, `limit`. Lists subscriptions from the global subscription index. |
+| `get_subscriptions_for_account` | Anyone | 0 | `account_id`, `from_index`, `limit`. Lists subscriptions by subscriber account. |
+| `get_subscriptions_for_product` | Anyone | 0 | `product_id`, `from_index`, `limit`. Lists subscriptions by current product. |
 
 ---
 

--- a/staking-contract/src/accounts.rs
+++ b/staking-contract/src/accounts.rs
@@ -59,7 +59,7 @@ impl Contract {
 
         let refund_yocto = attached.as_yoctonear().saturating_sub(accepted_yocto);
         if refund_yocto > 0 {
-            Promise::new(predecessor).transfer(NearToken::from_yoctonear(refund_yocto));
+            let _ = Promise::new(predecessor).transfer(NearToken::from_yoctonear(refund_yocto));
         }
 
         self.internal_storage_balance_of(&account_id)
@@ -105,7 +105,8 @@ impl Contract {
             .expect("Internal error: storage withdraw amount was not bounded correctly");
         self.internal_set_account(account_id.clone(), account);
 
-        Promise::new(account_id.clone()).transfer(NearToken::from_yoctonear(withdraw_yocto));
+        let _ =
+            Promise::new(account_id.clone()).transfer(NearToken::from_yoctonear(withdraw_yocto));
 
         self.internal_storage_balance_of(&account_id)
             .expect("Registered account must have a storage balance")
@@ -131,14 +132,43 @@ impl Contract {
         }
 
         self.accounts.remove(&account_id);
+        self.account_ids.remove(&account_id);
         if account.storage_deposit.as_yoctonear() > 0 {
-            Promise::new(account_id).transfer(account.storage_deposit);
+            let _ = Promise::new(account_id).transfer(account.storage_deposit);
         }
         true
     }
 
     pub fn get_account(&self, account_id: AccountId) -> Option<Account> {
         self.internal_get_account(&account_id)
+    }
+
+    pub fn get_account_ids(&self, from_index: u64, limit: u64) -> Vec<AccountId> {
+        let skip = usize::try_from(from_index).unwrap_or(usize::MAX);
+        let take = usize::try_from(limit).unwrap_or(usize::MAX);
+        self.account_ids
+            .iter()
+            .skip(skip)
+            .take(take)
+            .cloned()
+            .collect()
+    }
+
+    pub fn get_accounts(&self, from_index: u64, limit: u64) -> Vec<AccountView> {
+        let skip = usize::try_from(from_index).unwrap_or(usize::MAX);
+        let take = usize::try_from(limit).unwrap_or(usize::MAX);
+        self.account_ids
+            .iter()
+            .skip(skip)
+            .take(take)
+            .filter_map(|account_id| {
+                let account = self.internal_get_account(account_id)?;
+                Some(AccountView {
+                    account_id: account_id.clone(),
+                    storage_deposit: account.storage_deposit,
+                })
+            })
+            .collect()
     }
 }
 
@@ -148,7 +178,8 @@ impl Contract {
     }
 
     pub(crate) fn internal_set_account(&mut self, id: AccountId, account: Account) {
-        self.accounts.insert(id, account.into());
+        self.accounts.insert(id.clone(), account.into());
+        self.account_ids.insert(id);
     }
 
     fn internal_storage_balance_of(&self, account_id: &AccountId) -> Option<StorageBalance> {

--- a/staking-contract/src/lib.rs
+++ b/staking-contract/src/lib.rs
@@ -24,7 +24,7 @@ pub mod withdraw;
 pub use config::Config;
 pub use types::*;
 
-use near_sdk::store::{IterableMap, LookupMap, Vector};
+use near_sdk::store::{IterableMap, IterableSet, LookupMap, Vector};
 use near_sdk::{AccountId, BorshStorageKey, NearToken, PanicOnDefault, near};
 
 #[derive(BorshStorageKey)]
@@ -60,6 +60,9 @@ enum StorageKeys {
     UserPendingUnstakeValidatorCount,
     PurchasesByAccountVector { account_hash: Vec<u8> },
     PurchasesByProductVector { product_hash: Vec<u8> },
+    SubscriptionsByProduct,
+    SubscriptionsByProductSet { product_hash: Vec<u8> },
+    AccountIds,
 }
 
 #[derive(PanicOnDefault)]
@@ -83,6 +86,9 @@ pub struct Contract {
     pub prices: LookupMap<PriceId, VPrice>,
     /// Per-user accounting: NEP-145-style registered storage (`storage_deposit`).
     pub accounts: LookupMap<AccountId, VAccount>,
+    /// Enumerable registered-account index. During migration this is backfilled for accounts
+    /// discoverable from existing enumerable records, and all later storage mutations maintain it.
+    pub account_ids: IterableSet<AccountId>,
     /// Subscription records keyed by [`Subscription::subscription_id`] (`sub_*`).
     pub subscriptions: LookupMap<SubscriptionId, VSubscription>,
     /// Active and historical locks keyed by [`Lock::lock_id`] (`lock_*`).
@@ -124,6 +130,8 @@ pub struct Contract {
     /// Secondary index: `subscriber` → owned subscription ids. Used for account-level listing and
     /// subscription-specific plan changes without scanning the full catalog.
     pub subscriptions_by_account: LookupMap<AccountId, Vec<SubscriptionId>>,
+    /// Secondary index: product id -> subscription ids currently stored under that product.
+    pub subscriptions_by_product: LookupMap<ProductId, IterableSet<SubscriptionId>>,
     /// Subscription ids keyed for efficient membership and removal while remaining iterable for views.
     pub subscription_ids: IterableMap<SubscriptionId, ()>,
     /// Pending subscription-update target price reference counts, used by bounded catalog guards.
@@ -148,6 +156,7 @@ impl Contract {
             products: LookupMap::new(StorageKeys::Products),
             prices: LookupMap::new(StorageKeys::Prices),
             accounts: LookupMap::new(StorageKeys::Accounts),
+            account_ids: IterableSet::new(StorageKeys::AccountIds),
             subscriptions: LookupMap::new(StorageKeys::Subscriptions),
             locks: LookupMap::new(StorageKeys::Locks),
             user_validator_shares: LookupMap::new(StorageKeys::UserValidatorShares),
@@ -173,6 +182,7 @@ impl Contract {
                 StorageKeys::SubscriptionByAccountProduct,
             ),
             subscriptions_by_account: LookupMap::new(StorageKeys::SubscriptionsByAccount),
+            subscriptions_by_product: LookupMap::new(StorageKeys::SubscriptionsByProduct),
             subscription_ids: IterableMap::new(StorageKeys::SubscriptionIds),
             pending_update_target_price_counts: LookupMap::new(
                 StorageKeys::PendingUpdateTargetPriceCounts,

--- a/staking-contract/src/lock.rs
+++ b/staking-contract/src/lock.rs
@@ -1,14 +1,7 @@
-use crate::utils::{NS_PER_DAY_TIMESTAMP, block_timestamp, check_near_price_lock};
+use crate::utils::{block_timestamp, check_near_price_lock};
 use crate::*;
 use near_sdk::json_types::{U64, U128};
 use near_sdk::{AccountId, NearToken, PromiseOrValue, env, near, require};
-
-/// Stripe-style **billing anchor day** (1–31). Not the real UTC calendar day-of-month; it is a stable
-/// fingerprint from block time until civil-calendar billing is implemented.
-fn anchor_day_from_timestamp(ts: u64) -> u8 {
-    let d = (ts / NS_PER_DAY_TIMESTAMP) % 31;
-    (d as u8 + 1).min(31)
-}
 
 #[near]
 impl Contract {
@@ -344,7 +337,7 @@ impl Contract {
         price_id: &PriceId,
         start_ns: u64,
     ) -> (SubscriptionId, Subscription) {
-        let anchor = anchor_day_from_timestamp(start_ns);
+        let anchor = crate::subscriptions::billing_anchor_day_from_timestamp(start_ns);
         let end_ns = crate::subscriptions::add_months_stripe_style(anchor, 1, start_ns);
         let subscription_id = crate::ids::next_subscription_id(&mut self.id_nonce);
         let subscription = Subscription {

--- a/staking-contract/src/subscriptions.rs
+++ b/staking-contract/src/subscriptions.rs
@@ -1,8 +1,10 @@
-//! Subscription billing helpers (Stripe-style linear months) and subscription **lifecycle** RPCs
+//! Subscription billing helpers (Stripe-style calendar months) and subscription **lifecycle** RPCs
 //! (`cancel_subscription`, `update_subscription`, …). Subscription **locking** (`lock`)
 //! stays in [`crate::lock`] because it shares the pool refresh / mint pipeline with product locks.
 
-use crate::utils::{AVG_MONTH_NS, block_timestamp, check_near_price_lock, near_from_shares};
+use crate::utils::{
+    AVG_MONTH_NS, NS_PER_DAY_TIMESTAMP, block_timestamp, check_near_price_lock, near_from_shares,
+};
 use crate::*;
 use common::U256;
 use near_sdk::borsh::BorshSerialize;
@@ -13,13 +15,72 @@ use near_sdk::{AccountId, NearToken, PromiseOrValue, assert_one_yocto, env, near
 #[cfg(feature = "test")]
 const TEST_SUBSCRIPTION_TIMESTAMP_PREFIX: &[u8] = b"_test_subscription_timestamp_";
 
-/// Extend `from_ns` by `months` × average Gregorian months (linear approximation).
-/// `anchor_day` is validated but not yet applied.
+/// Extend `from_ns` by UTC calendar months, preserving time of day.
+///
+/// The target day is the billing anchor clamped to the last valid day of the target month.
 pub fn add_months_stripe_style(anchor_day: u8, months: u32, from_ns: u64) -> u64 {
-    let _anchor_day = anchor_day.clamp(1, 31);
-    let add_ns = (months as u128).saturating_mul(AVG_MONTH_NS);
-    let add_u64 = u64::try_from(add_ns).unwrap_or(u64::MAX);
-    from_ns.saturating_add(add_u64)
+    if months == 0 {
+        return from_ns;
+    }
+
+    let anchor_day = u32::from(anchor_day.clamp(1, 31));
+    let days = from_ns / NS_PER_DAY_TIMESTAMP;
+    let time_of_day_ns = from_ns % NS_PER_DAY_TIMESTAMP;
+    let (year, month, _day) = civil_from_days(days as i64);
+
+    let target_month_index = i128::from(year) * 12 + i128::from(month - 1) + i128::from(months);
+    let target_year = target_month_index.div_euclid(12);
+    let target_month = u32::try_from(target_month_index.rem_euclid(12) + 1).unwrap_or(12);
+    let target_day = anchor_day.min(last_day_of_month(target_year, target_month));
+    let target_days = days_from_civil(target_year, target_month, target_day);
+    let target_ns = target_days * i128::from(NS_PER_DAY_TIMESTAMP) + i128::from(time_of_day_ns);
+
+    u64::try_from(target_ns).unwrap_or(u64::MAX)
+}
+
+pub(crate) fn billing_anchor_day_from_timestamp(ts: u64) -> u8 {
+    let days = ts / NS_PER_DAY_TIMESTAMP;
+    let (_year, _month, day) = civil_from_days(days as i64);
+    day as u8
+}
+
+fn civil_from_days(days_since_unix_epoch: i64) -> (i64, u32, u32) {
+    let z = days_since_unix_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += if month <= 2 { 1 } else { 0 };
+    (year, month as u32, day as u32)
+}
+
+fn days_from_civil(year: i128, month: u32, day: u32) -> i128 {
+    let year = year - if month <= 2 { 1 } else { 0 };
+    let era = year.div_euclid(400);
+    let year_of_era = year - era * 400;
+    let month_prime = i128::from(month) + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * month_prime + 2) / 5 + i128::from(day) - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+fn last_day_of_month(year: i128, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 31,
+    }
+}
+
+fn is_leap_year(year: i128) -> bool {
+    year.rem_euclid(4) == 0 && year.rem_euclid(100) != 0 || year.rem_euclid(400) == 0
 }
 
 struct SubscriptionUpdateInputs {
@@ -1360,9 +1421,65 @@ impl Contract {
 mod tests {
     use super::*;
 
+    const JUL_28_2026_063128_629578_NS: u64 = 1_785_220_288_629_578_000;
+    const AUG_28_2026_063128_629578_NS: u64 = 1_787_898_688_629_578_000;
+
+    fn ns_for_utc(
+        year: i128,
+        month: u32,
+        day: u32,
+        hour: u32,
+        minute: u32,
+        second: u32,
+        nanosecond: u32,
+    ) -> u64 {
+        let days_ns = days_from_civil(year, month, day) * i128::from(NS_PER_DAY_TIMESTAMP);
+        let time_ns = u64::from(hour) * 3_600_000_000_000
+            + u64::from(minute) * 60_000_000_000
+            + u64::from(second) * 1_000_000_000
+            + u64::from(nanosecond);
+        u64::try_from(days_ns + i128::from(time_ns)).expect("test timestamp fits u64")
+    }
+
     #[test]
-    fn linear_month_stack() {
-        let out = add_months_stripe_style(15, 2, 100);
-        assert_eq!(out, 100 + (2u128 * AVG_MONTH_NS) as u64);
+    fn calendar_month_preserves_day_and_time_of_day() {
+        assert_eq!(
+            add_months_stripe_style(28, 1, JUL_28_2026_063128_629578_NS),
+            AUG_28_2026_063128_629578_NS
+        );
+    }
+
+    #[test]
+    fn calendar_month_clamps_end_of_month() {
+        let start = ns_for_utc(2026, 1, 31, 10, 0, 0, 0);
+        let feb_end = ns_for_utc(2026, 2, 28, 10, 0, 0, 0);
+        let mar_end = ns_for_utc(2026, 3, 31, 10, 0, 0, 0);
+
+        assert_eq!(add_months_stripe_style(31, 1, start), feb_end);
+        assert_eq!(add_months_stripe_style(31, 1, feb_end), mar_end);
+    }
+
+    #[test]
+    fn calendar_month_clamps_leap_year_february() {
+        let start = ns_for_utc(2028, 1, 31, 10, 0, 0, 0);
+        let expected = ns_for_utc(2028, 2, 29, 10, 0, 0, 0);
+
+        assert_eq!(add_months_stripe_style(31, 1, start), expected);
+    }
+
+    #[test]
+    fn calendar_month_multi_month_add_preserves_anchor_and_time() {
+        let start = ns_for_utc(2026, 1, 15, 23, 59, 59, 123);
+        let expected = ns_for_utc(2027, 3, 15, 23, 59, 59, 123);
+
+        assert_eq!(add_months_stripe_style(15, 14, start), expected);
+    }
+
+    #[test]
+    fn billing_anchor_day_uses_utc_day_of_month() {
+        assert_eq!(
+            billing_anchor_day_from_timestamp(JUL_28_2026_063128_629578_NS),
+            28
+        );
     }
 }

--- a/staking-contract/src/subscriptions.rs
+++ b/staking-contract/src/subscriptions.rs
@@ -7,7 +7,7 @@ use crate::*;
 use common::U256;
 use near_sdk::borsh::BorshSerialize;
 use near_sdk::json_types::{U64, U128};
-use near_sdk::store::LookupMap;
+use near_sdk::store::{IterableSet, LookupMap};
 use near_sdk::{AccountId, NearToken, PromiseOrValue, assert_one_yocto, env, near, require};
 
 #[cfg(feature = "test")]
@@ -208,6 +208,37 @@ impl Contract {
                 .map(|sub| self.project_subscription_view_now(sub))
         })
     }
+
+    pub fn get_subscriptions(&self, from_index: u64, limit: u64) -> Vec<Subscription> {
+        let skip = usize::try_from(from_index).unwrap_or(usize::MAX);
+        let take = usize::try_from(limit).unwrap_or(usize::MAX);
+        self.subscription_ids
+            .keys()
+            .skip(skip)
+            .take(take)
+            .filter_map(|id| self.internal_get_subscription(id))
+            .map(|sub| self.project_subscription_view_now(sub))
+            .collect()
+    }
+
+    pub fn get_subscriptions_for_product(
+        &self,
+        product_id: ProductId,
+        from_index: u64,
+        limit: u64,
+    ) -> Vec<Subscription> {
+        let Some(ids) = self.subscriptions_by_product.get(&product_id) else {
+            return Vec::new();
+        };
+        let skip = usize::try_from(from_index).unwrap_or(usize::MAX);
+        let take = usize::try_from(limit).unwrap_or(usize::MAX);
+        ids.iter()
+            .skip(skip)
+            .take(take)
+            .filter_map(|id| self.internal_get_subscription(id))
+            .map(|sub| self.project_subscription_view_now(sub))
+            .collect()
+    }
 }
 
 // Epoch pipeline: subscription update tail callback.
@@ -340,6 +371,7 @@ impl Contract {
         ids.push(subscription_id.clone());
         self.subscriptions_by_account
             .insert(account_id.clone(), ids);
+        self.add_subscription_to_product_index(account_id, subscription_id);
 
         if add_global {
             self.subscription_ids.insert(subscription_id.clone(), ());
@@ -367,12 +399,82 @@ impl Contract {
             self.subscriptions_by_account
                 .insert(account_id.clone(), ids);
         }
+        self.remove_subscription_from_product_index(subscription_id);
 
         if !remove_global {
             return;
         }
 
         self.subscription_ids.remove(subscription_id);
+    }
+
+    fn add_subscription_to_product_index(
+        &mut self,
+        account_id: &AccountId,
+        subscription_id: &SubscriptionId,
+    ) {
+        let Some(subscription) = self.internal_get_subscription(subscription_id) else {
+            return;
+        };
+        // The caller supplies the account index owner; verify it matches the
+        // stored subscription before mirroring that subscription into a product index.
+        if subscription.account_id != *account_id {
+            return;
+        }
+
+        self.add_subscription_to_product_index_for_product(
+            &subscription.product_id,
+            subscription_id,
+        );
+    }
+
+    fn add_subscription_to_product_index_for_product(
+        &mut self,
+        product_id: &ProductId,
+        subscription_id: &SubscriptionId,
+    ) {
+        if let Some(ids) = self.subscriptions_by_product.get_mut(product_id) {
+            ids.insert(subscription_id.clone());
+            return;
+        }
+
+        let mut ids = IterableSet::new(Self::subscriptions_by_product_set_key(product_id));
+        ids.insert(subscription_id.clone());
+        self.subscriptions_by_product
+            .insert(product_id.clone(), ids);
+    }
+
+    fn remove_subscription_from_product_index(&mut self, subscription_id: &SubscriptionId) {
+        let Some(subscription) = self.internal_get_subscription(subscription_id) else {
+            return;
+        };
+        self.remove_subscription_from_product_index_for_product(
+            &subscription.product_id,
+            subscription_id,
+        );
+    }
+
+    fn remove_subscription_from_product_index_for_product(
+        &mut self,
+        product_id: &ProductId,
+        subscription_id: &SubscriptionId,
+    ) {
+        let should_remove_product = {
+            let Some(ids) = self.subscriptions_by_product.get_mut(product_id) else {
+                return;
+            };
+            ids.remove(subscription_id);
+            ids.is_empty()
+        };
+        if should_remove_product {
+            self.subscriptions_by_product.remove(product_id);
+        }
+    }
+
+    pub(crate) fn subscriptions_by_product_set_key(product_id: &ProductId) -> StorageKeys {
+        StorageKeys::SubscriptionsByProductSet {
+            product_hash: env::sha256(product_id.as_bytes()),
+        }
     }
 
     pub(crate) fn assert_no_pending_update_references_price(&self, price_id: &PriceId) {
@@ -471,6 +573,8 @@ impl Contract {
                 self.subscription_by_account_product.remove(&old_key);
             }
         }
+        self.remove_subscription_from_product_index_for_product(old_product_id, subscription_id);
+        self.add_subscription_to_product_index_for_product(new_product_id, subscription_id);
     }
 
     pub(crate) fn require_subscription_by_id(

--- a/staking-contract/src/types.rs
+++ b/staking-contract/src/types.rs
@@ -95,6 +95,13 @@ pub struct Account {
     pub storage_deposit: NearToken,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near(serializers = [json])]
+pub struct AccountView {
+    pub account_id: AccountId,
+    pub storage_deposit: NearToken,
+}
+
 impl Default for Account {
     fn default() -> Self {
         Self {

--- a/staking-contract/src/upgrade.rs
+++ b/staking-contract/src/upgrade.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use near_sdk::env;
-use near_sdk::store::{IterableMap, LookupMap, Vector};
+use near_sdk::store::{IterableMap, IterableSet, LookupMap, Vector};
 
 #[cfg(target_arch = "wasm32")]
 use near_sdk::{Gas, sys};
@@ -15,7 +15,7 @@ impl Contract {
     #[private]
     #[init(ignore_state)]
     pub fn migrate_state() -> Self {
-        let old: ContractV1_0_1 = env::state_read().unwrap();
+        let old: ContractV1_1_1 = env::state_read().unwrap();
         old.into()
     }
 
@@ -26,7 +26,7 @@ impl Contract {
 
 #[allow(non_camel_case_types)]
 #[near(serializers = [borsh])]
-struct ContractV1_0_1 {
+struct ContractV1_1_1 {
     pub config: VConfig,
     pub paused: bool,
     pub validators: LookupMap<ValidatorId, VValidator>,
@@ -39,72 +39,65 @@ struct ContractV1_0_1 {
     pub locks: LookupMap<LockId, VLock>,
     pub user_validator_shares: LookupMap<(AccountId, ValidatorId), u128>,
     pub user_pending_unstake: LookupMap<(AccountId, ValidatorId), Vec<PendingUnstakeTranche>>,
+    pub user_pending_unstake_validator_count: LookupMap<AccountId, u32>,
     pub user_lock_count: LookupMap<AccountId, u32>,
     pub purchases: LookupMap<PurchaseId, VPurchase>,
     pub purchase_ids: Vector<PurchaseId>,
-    pub purchases_by_account: LookupMap<AccountId, Vec<PurchaseId>>,
-    pub purchases_by_product: LookupMap<ProductId, Vec<PurchaseId>>,
+    pub purchases_by_account: LookupMap<AccountId, Vector<PurchaseId>>,
+    pub purchases_by_product: LookupMap<ProductId, Vector<PurchaseId>>,
     pub user_purchase_count: LookupMap<AccountId, u32>,
     pub revenue_by_validator: LookupMap<ValidatorId, NearToken>,
+    pub farm_pools: LookupMap<PriceId, VFarmPool>,
+    pub farm_positions: LookupMap<(AccountId, ProductId), VFarmPosition>,
+    pub farm_position_products_by_account: LookupMap<AccountId, Vec<ProductId>>,
+    pub user_farm_position_count: LookupMap<AccountId, u32>,
+    pub farm_accounts: LookupMap<AccountId, VFarmAccount>,
     pub subscription_by_account_product: LookupMap<(AccountId, ProductId), SubscriptionId>,
     pub subscriptions_by_account: LookupMap<AccountId, Vec<SubscriptionId>>,
-    pub subscription_ids: Vector<SubscriptionId>,
+    pub subscription_ids: IterableMap<SubscriptionId, ()>,
     pub pending_update_target_price_counts: LookupMap<PriceId, u32>,
     pub pending_update_target_product_counts: LookupMap<ProductId, u32>,
     pub id_nonce: u64,
 }
 
-impl From<ContractV1_0_1> for Contract {
-    fn from(old: ContractV1_0_1) -> Self {
-        let mut user_pending_unstake_validator_count =
-            LookupMap::new(StorageKeys::UserPendingUnstakeValidatorCount);
-        for validator_id in old.validator_ids.iter() {
-            if let Some(validator) = old.validators.get(validator_id) {
-                for account_id in validator.legacy_accounts_with_pending_unstake() {
-                    let next = user_pending_unstake_validator_count
-                        .get(account_id)
-                        .copied()
-                        .unwrap_or(0u32)
-                        .saturating_add(1);
-                    user_pending_unstake_validator_count.insert(account_id.clone(), next);
-                }
+impl From<ContractV1_1_1> for Contract {
+    fn from(old: ContractV1_1_1) -> Self {
+        let mut account_ids = IterableSet::new(StorageKeys::AccountIds);
+        let mut subscriptions_by_product = LookupMap::new(StorageKeys::SubscriptionsByProduct);
+
+        for (subscription_id, _) in old.subscription_ids.iter() {
+            if let Some(subscription) = old.subscriptions.get(subscription_id) {
+                let subscription: Subscription = subscription.clone().into();
+                index_account_if_registered(
+                    &mut account_ids,
+                    &old.accounts,
+                    &subscription.account_id,
+                );
+                add_subscription_to_product_index_for_migration(
+                    &mut subscriptions_by_product,
+                    &subscription.product_id,
+                    subscription_id,
+                );
             }
         }
 
-        let mut subscription_ids = IterableMap::new(StorageKeys::SubscriptionIds);
-        for subscription_id in old.subscription_ids.iter() {
-            subscription_ids.insert(subscription_id.clone(), ());
-        }
-
-        let mut purchases_by_account: LookupMap<AccountId, Vector<PurchaseId>> =
-            LookupMap::new(StorageKeys::PurchasesByAccount);
-        let mut purchases_by_product: LookupMap<ProductId, Vector<PurchaseId>> =
-            LookupMap::new(StorageKeys::PurchasesByProduct);
         for purchase_id in old.purchase_ids.iter() {
             if let Some(purchase) = old.purchases.get(purchase_id) {
                 let purchase: Purchase = purchase.clone().into();
-                if let Some(ids) = purchases_by_account.get_mut(&purchase.account_id) {
-                    ids.push(purchase_id.clone());
-                } else {
-                    let mut ids =
-                        Vector::new(Self::purchases_by_account_vector_key(&purchase.account_id));
-                    ids.push(purchase_id.clone());
-                    purchases_by_account.insert(purchase.account_id.clone(), ids);
-                }
+                index_account_if_registered(&mut account_ids, &old.accounts, &purchase.account_id);
+            }
+        }
 
-                if let Some(ids) = purchases_by_product.get_mut(&purchase.product_id) {
-                    ids.push(purchase_id.clone());
-                } else {
-                    let mut ids =
-                        Vector::new(Self::purchases_by_product_vector_key(&purchase.product_id));
-                    ids.push(purchase_id.clone());
-                    purchases_by_product.insert(purchase.product_id.clone(), ids);
+        for validator_id in old.validator_ids.iter() {
+            if let Some(validator) = old.validators.get(validator_id) {
+                for account_id in validator.legacy_accounts_with_pending_unstake() {
+                    index_account_if_registered(&mut account_ids, &old.accounts, account_id);
                 }
             }
         }
 
         Self {
-            config: Config::from(old.config).into(),
+            config: old.config,
             paused: old.paused,
             validators: old.validators,
             validator_ids: old.validator_ids,
@@ -112,33 +105,58 @@ impl From<ContractV1_0_1> for Contract {
             products: old.products,
             prices: old.prices,
             accounts: old.accounts,
+            account_ids,
             subscriptions: old.subscriptions,
             locks: old.locks,
             user_validator_shares: old.user_validator_shares,
             user_pending_unstake: old.user_pending_unstake,
-            user_pending_unstake_validator_count,
+            user_pending_unstake_validator_count: old.user_pending_unstake_validator_count,
             user_lock_count: old.user_lock_count,
-            user_farm_position_count: LookupMap::new(StorageKeys::UserFarmPositionCount),
             purchases: old.purchases,
             purchase_ids: old.purchase_ids,
-            purchases_by_account,
-            purchases_by_product,
+            purchases_by_account: old.purchases_by_account,
+            purchases_by_product: old.purchases_by_product,
             user_purchase_count: old.user_purchase_count,
             revenue_by_validator: old.revenue_by_validator,
-            farm_pools: LookupMap::new(StorageKeys::FarmPools),
-            farm_positions: LookupMap::new(StorageKeys::FarmPositions),
-            farm_position_products_by_account: LookupMap::new(
-                StorageKeys::FarmPositionProductsByAccount,
-            ),
-            farm_accounts: LookupMap::new(StorageKeys::FarmAccounts),
+            farm_pools: old.farm_pools,
+            farm_positions: old.farm_positions,
+            farm_position_products_by_account: old.farm_position_products_by_account,
+            user_farm_position_count: old.user_farm_position_count,
+            farm_accounts: old.farm_accounts,
             subscription_by_account_product: old.subscription_by_account_product,
             subscriptions_by_account: old.subscriptions_by_account,
-            subscription_ids,
+            subscriptions_by_product,
+            subscription_ids: old.subscription_ids,
             pending_update_target_price_counts: old.pending_update_target_price_counts,
             pending_update_target_product_counts: old.pending_update_target_product_counts,
             id_nonce: old.id_nonce,
         }
     }
+}
+
+fn index_account_if_registered(
+    account_ids: &mut IterableSet<AccountId>,
+    old_accounts: &LookupMap<AccountId, VAccount>,
+    account_id: &AccountId,
+) {
+    if old_accounts.get(account_id).is_some() {
+        account_ids.insert(account_id.clone());
+    }
+}
+
+fn add_subscription_to_product_index_for_migration(
+    subscriptions_by_product: &mut LookupMap<ProductId, IterableSet<SubscriptionId>>,
+    product_id: &ProductId,
+    subscription_id: &SubscriptionId,
+) {
+    if let Some(ids) = subscriptions_by_product.get_mut(product_id) {
+        ids.insert(subscription_id.clone());
+        return;
+    }
+
+    let mut ids = IterableSet::new(Contract::subscriptions_by_product_set_key(product_id));
+    ids.insert(subscription_id.clone());
+    subscriptions_by_product.insert(product_id.clone(), ids);
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/staking-contract/src/upgrade.rs
+++ b/staking-contract/src/upgrade.rs
@@ -61,13 +61,16 @@ struct ContractV1_1_1 {
 }
 
 impl From<ContractV1_1_1> for Contract {
-    fn from(old: ContractV1_1_1) -> Self {
+    fn from(mut old: ContractV1_1_1) -> Self {
         let mut account_ids = IterableSet::new(StorageKeys::AccountIds);
         let mut subscriptions_by_product = LookupMap::new(StorageKeys::SubscriptionsByProduct);
 
         for (subscription_id, _) in old.subscription_ids.iter() {
             if let Some(subscription) = old.subscriptions.get(subscription_id) {
-                let subscription: Subscription = subscription.clone().into();
+                let mut subscription: Subscription = subscription.clone().into();
+                normalize_subscription_anchor_day_for_migration(&mut subscription);
+                old.subscriptions
+                    .insert(subscription_id.clone(), subscription.clone().into());
                 index_account_if_registered(
                     &mut account_ids,
                     &old.accounts,
@@ -134,6 +137,11 @@ impl From<ContractV1_1_1> for Contract {
     }
 }
 
+fn normalize_subscription_anchor_day_for_migration(subscription: &mut Subscription) {
+    subscription.anchor_day =
+        crate::subscriptions::billing_anchor_day_from_timestamp(subscription.start_ns.0);
+}
+
 fn index_account_if_registered(
     account_ids: &mut IterableSet<AccountId>,
     old_accounts: &LookupMap<AccountId, VAccount>,
@@ -198,5 +206,160 @@ pub extern "C" fn upgrade() {
             GET_CONFIG_GAS.as_gas(),
         );
         sys::promise_return(promise_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use near_sdk::json_types::U64;
+    use near_sdk::test_utils::VMContextBuilder;
+    use near_sdk::{AccountId, NearToken, testing_env};
+
+    const JUL_28_2026_063128_629578_NS: u64 = 1_785_220_288_629_578_000;
+    const AUG_01_2026_000000_000000_NS: u64 = 1_785_542_400_000_000_000;
+    const AUG_28_2026_063128_629578_NS: u64 = 1_787_898_688_629_578_000;
+
+    fn acct(s: &str) -> AccountId {
+        s.parse().expect("valid account id")
+    }
+
+    fn test_config() -> Config {
+        Config {
+            owner_account_id: acct("owner.near"),
+            proposed_new_owner_account_id: None,
+            guardians: vec![],
+            min_lock_duration_ns: U64(1),
+            max_lock_duration_ns: U64(u64::MAX / 8),
+            epoch_unstake_settle_epochs: 4,
+            min_storage_deposit: NearToken::from_millinear(100),
+            per_lock_storage_stake: NearToken::from_near(0),
+            per_farm_position_storage_stake: NearToken::from_near(0),
+            per_purchase_storage_stake: NearToken::from_near(0),
+            min_lock_amount: NearToken::from_near(1),
+        }
+    }
+
+    fn test_context(block_timestamp_ns: u64) {
+        let account_id = acct("staking.near");
+        testing_env!(
+            VMContextBuilder::new()
+                .current_account_id(account_id.clone())
+                .predecessor_account_id(account_id.clone())
+                .signer_account_id(account_id)
+                .block_timestamp(block_timestamp_ns)
+                .build()
+        );
+    }
+
+    fn contract_v1_1_1_from_current(contract: Contract) -> ContractV1_1_1 {
+        let Contract {
+            config,
+            paused,
+            validators,
+            validator_ids,
+            product_ids,
+            products,
+            prices,
+            accounts,
+            account_ids: _,
+            subscriptions,
+            locks,
+            user_validator_shares,
+            user_pending_unstake,
+            user_pending_unstake_validator_count,
+            user_lock_count,
+            purchases,
+            purchase_ids,
+            purchases_by_account,
+            purchases_by_product,
+            user_purchase_count,
+            revenue_by_validator,
+            farm_pools,
+            farm_positions,
+            farm_position_products_by_account,
+            user_farm_position_count,
+            farm_accounts,
+            subscription_by_account_product,
+            subscriptions_by_account,
+            subscriptions_by_product: _,
+            subscription_ids,
+            pending_update_target_price_counts,
+            pending_update_target_product_counts,
+            id_nonce,
+        } = contract;
+
+        ContractV1_1_1 {
+            config,
+            paused,
+            validators,
+            validator_ids,
+            product_ids,
+            products,
+            prices,
+            accounts,
+            subscriptions,
+            locks,
+            user_validator_shares,
+            user_pending_unstake,
+            user_pending_unstake_validator_count,
+            user_lock_count,
+            purchases,
+            purchase_ids,
+            purchases_by_account,
+            purchases_by_product,
+            user_purchase_count,
+            revenue_by_validator,
+            farm_pools,
+            farm_positions,
+            farm_position_products_by_account,
+            user_farm_position_count,
+            farm_accounts,
+            subscription_by_account_product,
+            subscriptions_by_account,
+            subscription_ids,
+            pending_update_target_price_counts,
+            pending_update_target_product_counts,
+            id_nonce,
+        }
+    }
+
+    #[test]
+    fn migration_recomputes_legacy_subscription_anchor_day() {
+        test_context(AUG_01_2026_000000_000000_NS);
+        let mut current = Contract::new(test_config());
+        let subscription_id = "sub_legacy".to_string();
+        let subscription = Subscription {
+            subscription_id: subscription_id.clone(),
+            account_id: acct("buyer.near"),
+            product_id: "prod_legacy".to_string(),
+            price_id: "price_legacy".to_string(),
+            start_ns: U64(JUL_28_2026_063128_629578_NS),
+            end_ns: U64(AUG_28_2026_063128_629578_NS),
+            anchor_day: 17,
+            last_lock_id: "lock_legacy".to_string(),
+            status: SubscriptionStatus::Active,
+            cancel_at_period_end: false,
+            pending_update: None,
+        };
+        current
+            .subscriptions
+            .insert(subscription_id.clone(), subscription.into());
+        current.subscription_ids.insert(subscription_id.clone(), ());
+
+        let old = contract_v1_1_1_from_current(current);
+        let migrated: Contract = old.into();
+        let stored: Subscription = migrated
+            .subscriptions
+            .get(&subscription_id)
+            .expect("subscription migrated")
+            .clone()
+            .into();
+
+        assert_eq!(stored.anchor_day, 28);
+        assert_eq!(
+            migrated.project_subscription_view_now(stored).end_ns.0,
+            AUG_28_2026_063128_629578_NS
+        );
     }
 }

--- a/staking-contract/src/validators.rs
+++ b/staking-contract/src/validators.rs
@@ -299,7 +299,7 @@ impl Contract {
     /// NEAR `epoch_height` from which a new [`PendingUnstakeTranche`] may participate in
     /// [`crate::Contract::withdraw`] (when `env::epoch_height() >=` this value).
     ///
-    /// 1. `unstake_start_epoch = max(current_epoch_height, last_unstake_epoch + epoch_unstake_settle_epochs)`
+    /// 1. `unstake_start_epoch = max(current_epoch_height + 1, last_unstake_epoch + epoch_unstake_settle_epochs)`
     /// 2. `available_epoch_height = unstake_start_epoch + epoch_unstake_settle_epochs`
     ///
     /// Uses [`crate::config::Config::epoch_unstake_settle_epochs`].
@@ -309,8 +309,9 @@ impl Contract {
     ) -> u64 {
         let current_epoch_height = epoch_height();
         let settle = self.internal_get_config().epoch_unstake_settle_epochs;
+        let next_epoch_height = current_epoch_height.saturating_add(1);
         let unstake_start_epoch =
-            current_epoch_height.max(validator.last_unstake_epoch.saturating_add(settle));
+            next_epoch_height.max(validator.last_unstake_epoch.saturating_add(settle));
         unstake_start_epoch.saturating_add(settle)
     }
 
@@ -477,6 +478,87 @@ impl Contract {
         require!(
             validator.catalog_manager_account_ids.contains(caller),
             "Only the validator owner or catalog manager can call this method"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use near_sdk::json_types::U64;
+    use near_sdk::test_utils::VMContextBuilder;
+    use near_sdk::testing_env;
+
+    fn account(id: &str) -> AccountId {
+        id.parse().expect("valid account id")
+    }
+
+    fn contract_with_settle_epochs(settle_epochs: u64) -> Contract {
+        Contract::new(Config {
+            owner_account_id: account("owner.near"),
+            proposed_new_owner_account_id: None,
+            guardians: vec![],
+            min_lock_duration_ns: U64(1),
+            max_lock_duration_ns: U64(u64::MAX / 8),
+            epoch_unstake_settle_epochs: settle_epochs,
+            min_storage_deposit: NearToken::from_millinear(100),
+            per_lock_storage_stake: NearToken::from_near(0),
+            per_farm_position_storage_stake: NearToken::from_near(0),
+            per_purchase_storage_stake: NearToken::from_near(0),
+            min_lock_amount: NearToken::from_near(1),
+        })
+    }
+
+    fn validator_with_last_unstake_epoch(last_unstake_epoch: u64) -> Validator {
+        Validator {
+            validator_id: account("pool.near"),
+            catalog_manager_account_ids: Vec::new(),
+            status: ValidatorStatus::Active,
+            total_shares: U128(0),
+            total_staked_balance: NearToken::from_near(0),
+            last_balance_refresh_ns: U64(0),
+            pending_to_stake: NearToken::from_near(0),
+            pending_to_unstake: NearToken::from_near(0),
+            last_unstake_epoch,
+            last_settlement_epoch: 0,
+            pending_to_withdraw: NearToken::from_near(0),
+            pending_to_claim: NearToken::from_near(0),
+            tx_status: TransactionStatus::Idle,
+        }
+    }
+
+    fn set_epoch(epoch_height: u64) {
+        testing_env!(
+            VMContextBuilder::new()
+                .current_account_id(account("staking.near"))
+                .predecessor_account_id(account("buyer.near"))
+                .signer_account_id(account("buyer.near"))
+                .epoch_height(epoch_height)
+                .build()
+        );
+    }
+
+    #[test]
+    fn pending_unstake_tranche_waits_for_next_epoch_pool_unstake() {
+        set_epoch(100);
+        let contract = contract_with_settle_epochs(4);
+        let validator = validator_with_last_unstake_epoch(0);
+
+        assert_eq!(
+            contract.pending_unstake_tranche_available_epoch_height(&validator),
+            105
+        );
+    }
+
+    #[test]
+    fn pending_unstake_tranche_honors_prior_pool_unstake_spacing() {
+        set_epoch(100);
+        let contract = contract_with_settle_epochs(4);
+        let validator = validator_with_last_unstake_epoch(103);
+
+        assert_eq!(
+            contract.pending_unstake_tranche_available_epoch_height(&validator),
+            111
         );
     }
 }

--- a/staking-contract/tests/accounts_storage.rs
+++ b/staking-contract/tests/accounts_storage.rs
@@ -7,7 +7,7 @@ use common::{
     setup_catalog_near_oneoff,
 };
 use near_sdk::{NearToken, testing_env};
-use staking_contract::PendingUnstakeTranche;
+use staking_contract::{AccountView, PendingUnstakeTranche};
 
 #[test]
 fn storage_balance_of_returns_none_for_unregistered_account() {
@@ -39,6 +39,66 @@ fn storage_deposit_returns_updated_balance() {
     let stored = c.storage_balance_of(acct(BUYER)).expect("registered");
     assert_eq!(stored.total, balance.total);
     assert_eq!(stored.available, balance.available);
+}
+
+#[test]
+fn get_account_ids_lists_registered_accounts() {
+    let mut c = deploy_with_config(base_config());
+
+    testing_env!(ctx(acct(BUYER), NearToken::from_millinear(100)));
+    c.storage_deposit(None, None);
+    testing_env!(ctx(acct("second.testnet"), NearToken::from_millinear(100)));
+    c.storage_deposit(None, None);
+
+    assert_eq!(
+        c.get_account_ids(0, 10),
+        vec![acct(BUYER), acct("second.testnet")]
+    );
+    assert_eq!(c.get_account_ids(1, 1), vec![acct("second.testnet")]);
+    assert_eq!(
+        c.get_accounts(0, 10),
+        vec![
+            AccountView {
+                account_id: acct(BUYER),
+                storage_deposit: NearToken::from_millinear(100),
+            },
+            AccountView {
+                account_id: acct("second.testnet"),
+                storage_deposit: NearToken::from_millinear(100),
+            },
+        ]
+    );
+    assert_eq!(
+        c.get_accounts(1, 1),
+        vec![AccountView {
+            account_id: acct("second.testnet"),
+            storage_deposit: NearToken::from_millinear(100),
+        }]
+    );
+}
+
+#[test]
+fn get_account_ids_filters_unregistered_accounts_without_duplicates() {
+    let mut c = deploy_with_config(base_config());
+
+    testing_env!(ctx(acct(BUYER), NearToken::from_millinear(100)));
+    c.storage_deposit(None, None);
+    testing_env!(ctx(acct(BUYER), NearToken::from_yoctonear(1)));
+    assert!(c.storage_unregister(None));
+    assert!(c.get_account_ids(0, 10).is_empty());
+    assert!(c.get_accounts(0, 10).is_empty());
+
+    testing_env!(ctx(acct(BUYER), NearToken::from_millinear(100)));
+    c.storage_deposit(None, None);
+
+    assert_eq!(c.get_account_ids(0, 10), vec![acct(BUYER)]);
+    assert_eq!(
+        c.get_accounts(0, 10),
+        vec![AccountView {
+            account_id: acct(BUYER),
+            storage_deposit: NearToken::from_millinear(100),
+        }]
+    );
 }
 
 #[test]

--- a/staking-contract/tests/subscription_lifecycle.rs
+++ b/staking-contract/tests/subscription_lifecycle.rs
@@ -121,6 +121,36 @@ fn active_renewal_reuses_subscription_indexes() {
 }
 
 #[test]
+fn subscription_listing_views_return_projected_records() {
+    let mut c = deploy();
+    let (product_id, price_id) = setup_catalog_near_subscription(&mut c);
+    register_buyer(&mut c);
+
+    testing_env!(ctx_ts(acct(BUYER), NearToken::from_near(50), BASE_TS));
+    let _lock_id = unwrap_sync_lock_id(c.lock(Some(price_id.clone()), None, None));
+
+    let subscription = c
+        .get_subscription_for_product(acct(BUYER), product_id.clone())
+        .expect("subscription");
+    let all_subscriptions = c.get_subscriptions(0, 10);
+    assert_eq!(all_subscriptions.len(), 1);
+    assert_eq!(
+        all_subscriptions[0].subscription_id,
+        subscription.subscription_id
+    );
+    let product_subscriptions = c.get_subscriptions_for_product(product_id.clone(), 0, 10);
+    assert_eq!(product_subscriptions.len(), 1);
+    assert_eq!(
+        product_subscriptions[0].subscription_id,
+        subscription.subscription_id
+    );
+    assert!(
+        c.get_subscriptions_for_product(product_id, 1, 10)
+            .is_empty()
+    );
+}
+
+#[test]
 fn resume_subscription_clears_cancel_before_period_end() {
     let mut c = deploy();
     let (product_id, price_id) = setup_catalog_near_subscription(&mut c);

--- a/staking-contract/tests/subscription_lifecycle.rs
+++ b/staking-contract/tests/subscription_lifecycle.rs
@@ -18,6 +18,44 @@ use staking_contract::types::{LockStatus, OrderRef, SubscriptionStatus};
 use staking_contract::utils::AVG_MONTH_NS;
 
 const BASE_TS: u64 = 1_700_000_000_000_000_000;
+const JAN_31_2026_10_UTC_NS: u64 = 1_769_853_600_000_000_000;
+const FEB_28_2026_10_UTC_NS: u64 = 1_772_272_800_000_000_000;
+
+#[test]
+fn recurring_lock_uses_calendar_month_window_and_utc_anchor() {
+    let mut c = deploy();
+    let (product_id, price_id) = setup_catalog_near_subscription(&mut c);
+    register_buyer(&mut c);
+
+    testing_env!(ctx_ts(
+        acct(BUYER),
+        NearToken::from_near(50),
+        JAN_31_2026_10_UTC_NS
+    ));
+    let lock_id = unwrap_sync_lock_id(c.lock(Some(price_id.clone()), None, None));
+
+    let sub = c
+        .get_subscription_for_product(acct(BUYER), product_id)
+        .expect("subscription");
+    assert_eq!(sub.start_ns.0, JAN_31_2026_10_UTC_NS);
+    assert_eq!(sub.end_ns.0, FEB_28_2026_10_UTC_NS);
+    assert_eq!(sub.anchor_day, 31);
+
+    let lock = c.get_lock(lock_id).expect("lock");
+    assert_eq!(lock.start_ns, sub.start_ns);
+    assert_eq!(lock.end_ns, sub.end_ns);
+    match lock.order {
+        OrderRef::Subscription {
+            period_start_ns,
+            period_end_ns,
+            ..
+        } => {
+            assert_eq!(period_start_ns, sub.start_ns);
+            assert_eq!(period_end_ns, sub.end_ns);
+        }
+        OrderRef::ProductPurchase { .. } => panic!("expected subscription order"),
+    }
+}
 
 #[test]
 fn cancel_then_renew_after_period_opens_fresh_subscription() {


### PR DESCRIPTION
## Summary

- Adds account and subscription view coverage for staking-contract flows.
- Defers unstake tranche availability and expands validator pending-unstake handling.
- Fixes recurring subscription calendar-month billing behavior and migration handling.
- Updates stake v1 workflow triggers and staking-contract API documentation.

## Validation

- `make test-staking-contract`