### PR TITLE
fix: NEP-330 repository metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "1.1.1"
 authors = ["Fastnear Inc <hello@fastnear.com>"]
 edition = "2024"
-repository = "https://github.com/fastnear/house-of-stake-contracts"
+repository = "https://github.com/houseofstake/house-of-stake-contracts"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
## Summary
- Update the workspace `repository` metadata from `fastnear/house-of-stake-contracts` to `houseofstake/house-of-stake-contracts`.
- Keep contract crate metadata inherited through `repository.workspace = true`, so NEP-330 metadata points at the canonical repository.

## Validation
- `cargo metadata --no-deps --format-version 1`
- `rg -n "fastnear/house-of-stake-contracts|houseofstake/house-of-stake-contracts|repository.workspace" Cargo.toml */Cargo.toml staking-contract/cli/Cargo.toml`